### PR TITLE
Update build.gradle to prevent guava conflicts

### DIFF
--- a/cr-core/build.gradle
+++ b/cr-core/build.gradle
@@ -48,7 +48,8 @@ dependencies {
 
     testRuntime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
 
-    compile 'com.google.apis:google-api-services-drive:v2-rev193-1.20.0'
+    compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    compile ('com.google.apis:google-api-services-drive:v2-rev193-1.20.0'){exclude module: 'guava-jdk5'}
     //compile 'com.google.oauth-client:google-oauth-client-java6:1.19.0'
     //compile 'com.google.oauth-client:google-oauth-client-jetty:1.19.0'
 }


### PR DESCRIPTION
`com.google.apis:google-api-services-drive:v2-rev193-1.20.0` depends on `guava-jdk5`, which is no longer maintained as well as causes conflicts with vanilla guava when run with Terasology due to there being multiple instances of guava on the classpath. This is also mentioned in MovingBlocks/Terasology#2584. 

This PR fixes the issue by excluding `guava-jdk5` and instead including vanilla guava in the cr-core build.gradle. 