### PR TITLE
Non-critical mode for CR

### DIFF
--- a/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
@@ -25,7 +25,6 @@ import org.terasology.crashreporter.GlobalProperties.KEY;
 
 import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 
@@ -43,8 +42,9 @@ public final class CrashReporter {
      * Can be called from any thread.
      * @param throwable the exception to report
      * @param logFileFolder the log file folder or <code>null</code>
+     * @param ifCritical true if CrashReporter is in the critical mode
      */
-    public static void report(final Throwable throwable, final Path logFileFolder) {
+    public static void report(final Throwable throwable, final Path logFileFolder, final boolean ifCritical) {
         // Swing element methods must be called in the swing thread
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -58,7 +58,7 @@ public final class CrashReporter {
                         e.printStackTrace();
                     }
                     GlobalProperties properties = new GlobalProperties();
-                    showModalDialog(throwable, properties, logFileFolder);
+                    showModalDialog(throwable, properties, logFileFolder,ifCritical);
                     try {
                         UIManager.setLookAndFeel(oldLaF);
                     } catch (Exception e) {
@@ -71,15 +71,15 @@ public final class CrashReporter {
         }
     }
 
-    protected static void showModalDialog(Throwable throwable, GlobalProperties properties, Path logFolder) {
-        String dialogTitle = I18N.getMessage(GraphicsEnvironment.isHeadless() ? "dialogTitle" : "dialogTitleNonCritical");
+    protected static void showModalDialog(Throwable throwable, GlobalProperties properties, Path logFolder, boolean ifCritical) {
+        String dialogTitle = I18N.getMessage(ifCritical ? "dialogTitle" : "dialogTitleNonCritical");
         String version = Resources.getVersion();
 
         if (version != null) {
             dialogTitle += " " + version;
         }
 
-        RootPanel panel = new RootPanel(throwable, properties, logFolder);
+        RootPanel panel = new RootPanel(throwable, properties, logFolder,ifCritical);
         JDialog dialog = new JDialog((Dialog) null, dialogTitle, true);
         dialog.setIconImage(Resources.loadImage(properties.get(KEY.RES_SERVER_ICON)));
         dialog.setContentPane(panel);

--- a/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
@@ -20,6 +20,7 @@ import javax.swing.JDialog;
 import javax.swing.LookAndFeel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.WindowConstants;
 
 import org.terasology.crashreporter.GlobalProperties.KEY;
 
@@ -100,13 +101,13 @@ public final class CrashReporter {
         }
 
         RootPanel panel = new RootPanel(throwable, properties, logFolder, mode);
-        JDialog dialog = new JDialog((Dialog) null, dialogTitle, true);
+        JDialog dialog = new JDialog((Dialog) null, dialogTitle, false);
+        dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         dialog.setIconImage(Resources.loadImage(properties.get(KEY.RES_SERVER_ICON)));
         dialog.setContentPane(panel);
         dialog.setMinimumSize(new Dimension(600, 400));
         dialog.setLocationRelativeTo(null);
         dialog.setResizable(true);      // disabled by default
         dialog.setVisible(true);
-        dialog.dispose();
     }
 }

--- a/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/CrashReporter.java
@@ -25,6 +25,7 @@ import org.terasology.crashreporter.GlobalProperties.KEY;
 
 import java.awt.Dialog;
 import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 
@@ -71,7 +72,7 @@ public final class CrashReporter {
     }
 
     protected static void showModalDialog(Throwable throwable, GlobalProperties properties, Path logFolder) {
-        String dialogTitle = I18N.getMessage("dialogTitle");
+        String dialogTitle = I18N.getMessage(GraphicsEnvironment.isHeadless() ? "dialogTitle" : "dialogTitleNonCritical");
         String version = Resources.getVersion();
 
         if (version != null) {

--- a/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
@@ -24,7 +24,6 @@ import org.terasology.crashreporter.pages.UserInfoPanel;
 import org.terasology.gui.JImage;
 import org.terasology.gui.RXCardLayout;
 
-import javax.print.attribute.standard.Severity;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -59,9 +58,9 @@ public class RootPanel extends JPanel {
      * @param exception     the exception that occurred
      * @param properties    the properties for this dialog wizard
      * @param logFolderFile the log file or <code>null</code>
-     * @param severity      ERROR calls crash reporter, WARNING calls issue reporter, REPORT calls feedback window
+     * @param mode          crash reporter, issue reporter or feedback window
      */
-    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile, Severity severity) {
+    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile, CrashReporter.MODE mode) {
 
         setLayout(new BorderLayout());
         Font buttonFont = getFont().deriveFont(Font.BOLD, 14f);
@@ -71,7 +70,7 @@ public class RootPanel extends JPanel {
         final Icon closeIcon = Resources.loadIcon(properties.get(KEY.RES_EXIT_ICON));
 
         List<JComponent> pages = new ArrayList<>();
-        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile, severity);
+        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile, mode);
         pages.add(errorMessagePanel);
         final UserInfoPanel userInfoPanel = new UserInfoPanel(properties,
                 errorMessagePanel.getLog(), errorMessagePanel.getLogFile());

--- a/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
@@ -24,6 +24,7 @@ import org.terasology.crashreporter.pages.UserInfoPanel;
 import org.terasology.gui.JImage;
 import org.terasology.gui.RXCardLayout;
 
+import javax.print.attribute.standard.Severity;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JButton;
@@ -58,9 +59,9 @@ public class RootPanel extends JPanel {
      * @param exception     the exception that occurred
      * @param properties    the properties for this dialog wizard
      * @param logFolderFile the log file or <code>null</code>
-     * @param ifCritical    true if CrashReporter is in the critical mode
+     * @param severity      ERROR calls crash reporter, WARNING calls issue reporter, REPORT calls feedback window
      */
-    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile, boolean ifCritical) {
+    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile, Severity severity) {
 
         setLayout(new BorderLayout());
         Font buttonFont = getFont().deriveFont(Font.BOLD, 14f);
@@ -70,7 +71,7 @@ public class RootPanel extends JPanel {
         final Icon closeIcon = Resources.loadIcon(properties.get(KEY.RES_EXIT_ICON));
 
         List<JComponent> pages = new ArrayList<>();
-        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile, ifCritical);
+        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile, severity);
         pages.add(errorMessagePanel);
         final UserInfoPanel userInfoPanel = new UserInfoPanel(properties,
                 errorMessagePanel.getLog(), errorMessagePanel.getLogFile());

--- a/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
@@ -58,8 +58,9 @@ public class RootPanel extends JPanel {
      * @param exception     the exception that occurred
      * @param properties    the properties for this dialog wizard
      * @param logFolderFile the log file or <code>null</code>
+     * @param ifCritical    true if CrashReporter is in the critical mode
      */
-    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile) {
+    public RootPanel(Throwable exception, GlobalProperties properties, Path logFolderFile, boolean ifCritical) {
 
         setLayout(new BorderLayout());
         Font buttonFont = getFont().deriveFont(Font.BOLD, 14f);
@@ -69,7 +70,7 @@ public class RootPanel extends JPanel {
         final Icon closeIcon = Resources.loadIcon(properties.get(KEY.RES_EXIT_ICON));
 
         List<JComponent> pages = new ArrayList<>();
-        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile);
+        final ErrorMessagePanel errorMessagePanel = new ErrorMessagePanel(properties, exception, logFolderFile, ifCritical);
         pages.add(errorMessagePanel);
         final UserInfoPanel userInfoPanel = new UserInfoPanel(properties,
                 errorMessagePanel.getLog(), errorMessagePanel.getLogFile());

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -33,7 +33,6 @@ import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 import java.awt.BorderLayout;
 import java.awt.Font;
-import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -64,8 +63,10 @@ public class ErrorMessagePanel extends JPanel {
      * @param exception the exception to display
      * @param logFileFolder the folder that contains the relevant log files
      * @param properties    the properties for this dialog wizard
+     * @param ifCritical    true if CrashReporter is in the critical mode
+
      */
-    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder) {
+    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, boolean ifCritical) {
 
         JPanel mainPanel = this;
         mainPanel.setLayout(new BorderLayout(0, 5));
@@ -78,8 +79,8 @@ public class ErrorMessagePanel extends JPanel {
         // Replace newline chars. with html newline elements (not needed in most cases)
         text = text.replaceAll("\\r?\\n", "<br/>");
 
-        String firstLine = I18N.getMessage( (GraphicsEnvironment.isHeadless()) ? "firstLine" : "firstLineNonCritical");
-        Icon titleIcon = Resources.loadIcon(properties.get( (GraphicsEnvironment.isHeadless()) ? KEY.RES_ERROR_TITLE_IMAGE : KEY.RES_INFO_TITLE_IMAGE));
+        String firstLine = I18N.getMessage( ifCritical ? "firstLine" : "firstLineNonCritical");
+        Icon titleIcon = Resources.loadIcon(properties.get( ifCritical ? KEY.RES_ERROR_TITLE_IMAGE : KEY.RES_INFO_TITLE_IMAGE));
 
         String htmlText = "<html><h3>" + firstLine + "</h3>" + text + "</html>";
         JLabel message = new JLabel(htmlText, titleIcon, SwingConstants.LEFT);

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -18,12 +18,12 @@ package org.terasology.crashreporter.pages;
 
 import com.google.common.collect.Lists;
 
+import org.terasology.crashreporter.CrashReporter;
 import org.terasology.crashreporter.GlobalProperties;
 import org.terasology.crashreporter.GlobalProperties.KEY;
 import org.terasology.crashreporter.I18N;
 import org.terasology.crashreporter.Resources;
 
-import javax.print.attribute.standard.Severity;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JLabel;
@@ -61,13 +61,13 @@ public class ErrorMessagePanel extends JPanel {
     private final List<Path> logFiles;
 
     /**
-     * @param exception the exception to display
+     * @param exception     the exception to display
      * @param logFileFolder the folder that contains the relevant log files
      * @param properties    the properties for this dialog wizard
-     * @param severity      ERROR calls crash reporter, WARNING calls issue reporter, REPORT calls feedback window
+     * @param mode          crash reporter, issue reporter or feedback window
 
      */
-    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, Severity severity) {
+    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, CrashReporter.MODE mode) {
 
         JPanel mainPanel = this;
         mainPanel.setLayout(new BorderLayout(0, 5));
@@ -82,20 +82,21 @@ public class ErrorMessagePanel extends JPanel {
 
         String firstLine;
         Icon titleIcon;
-        if (severity == Severity.ERROR){
-            firstLine = I18N.getMessage("firstLineCrash");
-            titleIcon = Resources.loadIcon(properties.get( KEY.RES_ERROR_TITLE_IMAGE ));
+        switch (mode) {
+            case FEEDBACK:
+                //For future feedback mode
+                firstLine = I18N.getMessage("firstLineFeedback");
+                titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+                break;
+            case ISSUE_REPORTER:
+                firstLine = I18N.getMessage("firstLineIssue");
+                titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+                break;
+            default:
+                firstLine = I18N.getMessage("firstLineCrash");
+                titleIcon = Resources.loadIcon(properties.get( KEY.RES_ERROR_TITLE_IMAGE ));
+                break;
         }
-        else if(severity == Severity.WARNING){
-            firstLine = I18N.getMessage("firstLineIssue");
-            titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
-        }
-        else{
-            //For future feedback mode
-            firstLine = I18N.getMessage("firstLineFeedback");
-            titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
-        }
-
         String htmlText = "<html><h3>" + firstLine + "</h3>" + text + "</html>";
         JLabel message = new JLabel(htmlText, titleIcon, SwingConstants.LEFT);
 

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -33,6 +33,7 @@ import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 import java.awt.BorderLayout;
 import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -77,8 +78,8 @@ public class ErrorMessagePanel extends JPanel {
         // Replace newline chars. with html newline elements (not needed in most cases)
         text = text.replaceAll("\\r?\\n", "<br/>");
 
-        String firstLine = I18N.getMessage("firstLine");
-        Icon titleIcon = Resources.loadIcon(properties.get(KEY.RES_ERROR_TITLE_IMAGE));
+        String firstLine = I18N.getMessage( (GraphicsEnvironment.isHeadless()) ? "firstLine" : "firstLineNonCritical");
+        Icon titleIcon = Resources.loadIcon(properties.get( (GraphicsEnvironment.isHeadless()) ? KEY.RES_ERROR_TITLE_IMAGE : KEY.RES_INFO_TITLE_IMAGE));
 
         String htmlText = "<html><h3>" + firstLine + "</h3>" + text + "</html>";
         JLabel message = new JLabel(htmlText, titleIcon, SwingConstants.LEFT);

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -23,6 +23,7 @@ import org.terasology.crashreporter.GlobalProperties.KEY;
 import org.terasology.crashreporter.I18N;
 import org.terasology.crashreporter.Resources;
 
+import javax.print.attribute.standard.Severity;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JLabel;
@@ -63,10 +64,10 @@ public class ErrorMessagePanel extends JPanel {
      * @param exception the exception to display
      * @param logFileFolder the folder that contains the relevant log files
      * @param properties    the properties for this dialog wizard
-     * @param ifCritical    true if CrashReporter is in the critical mode
+     * @param severity      ERROR calls crash reporter, WARNING calls issue reporter, REPORT calls feedback window
 
      */
-    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, boolean ifCritical) {
+    public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, Severity severity) {
 
         JPanel mainPanel = this;
         mainPanel.setLayout(new BorderLayout(0, 5));
@@ -79,8 +80,21 @@ public class ErrorMessagePanel extends JPanel {
         // Replace newline chars. with html newline elements (not needed in most cases)
         text = text.replaceAll("\\r?\\n", "<br/>");
 
-        String firstLine = I18N.getMessage( ifCritical ? "firstLine" : "firstLineNonCritical");
-        Icon titleIcon = Resources.loadIcon(properties.get( ifCritical ? KEY.RES_ERROR_TITLE_IMAGE : KEY.RES_INFO_TITLE_IMAGE));
+        String firstLine;
+        Icon titleIcon;
+        if (severity == Severity.ERROR){
+            firstLine = I18N.getMessage("firstLineCrash");
+            titleIcon = Resources.loadIcon(properties.get( KEY.RES_ERROR_TITLE_IMAGE ));
+        }
+        else if(severity == Severity.WARNING){
+            firstLine = I18N.getMessage("firstLineIssue");
+            titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+        }
+        else{
+            //For future feedback mode
+            firstLine = I18N.getMessage("firstLineFeedback");
+            titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+        }
 
         String htmlText = "<html><h3>" + firstLine + "</h3>" + text + "</html>";
         JLabel message = new JLabel(htmlText, titleIcon, SwingConstants.LEFT);

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2017 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,12 @@ import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 import java.awt.BorderLayout;
 import java.awt.Font;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.RandomAccessFile;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.file.FileVisitOption;
@@ -50,7 +54,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 /**
- * Shows the error message plus stack trace
+ * Shows the error message plus stack trace.
  */
 public class ErrorMessagePanel extends JPanel {
 
@@ -60,12 +64,16 @@ public class ErrorMessagePanel extends JPanel {
     private final List<JTextArea> textAreas = Lists.newArrayList();
     private final List<Path> logFiles;
 
+    private final LogUpdateWorker logUpdateWorker;
+
+    // logReaders is the list of each log file's reader
+    private final List<RandomAccessFile> logReaders = Lists.newArrayList();
+
     /**
      * @param exception     the exception to display
      * @param logFileFolder the folder that contains the relevant log files
      * @param properties    the properties for this dialog wizard
      * @param mode          crash reporter, issue reporter or feedback window
-
      */
     public ErrorMessagePanel(GlobalProperties properties, Throwable exception, Path logFileFolder, CrashReporter.MODE mode) {
 
@@ -86,15 +94,15 @@ public class ErrorMessagePanel extends JPanel {
             case FEEDBACK:
                 //For future feedback mode
                 firstLine = I18N.getMessage("firstLineFeedback");
-                titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+                titleIcon = Resources.loadIcon(properties.get(KEY.RES_INFO_TITLE_IMAGE));
                 break;
             case ISSUE_REPORTER:
                 firstLine = I18N.getMessage("firstLineIssue");
-                titleIcon = Resources.loadIcon(properties.get( KEY.RES_INFO_TITLE_IMAGE ));
+                titleIcon = Resources.loadIcon(properties.get(KEY.RES_INFO_TITLE_IMAGE));
                 break;
             default:
                 firstLine = I18N.getMessage("firstLineCrash");
-                titleIcon = Resources.loadIcon(properties.get( KEY.RES_ERROR_TITLE_IMAGE ));
+                titleIcon = Resources.loadIcon(properties.get(KEY.RES_ERROR_TITLE_IMAGE));
                 break;
         }
         String htmlText = "<html><h3>" + firstLine + "</h3>" + text + "</html>";
@@ -114,6 +122,16 @@ public class ErrorMessagePanel extends JPanel {
                 String tabName = logFileFolder.relativize(logFile).toString();
                 tabPane.addTab(tabName, new JScrollPane(logArea));
                 textAreas.add(logArea);
+
+                // Add reader of each log file in logReaders
+                try {
+                    File file = logFile.toFile();
+                    RandomAccessFile logReader = new RandomAccessFile(file, "r");
+                    logReader.seek(file.length());
+                    logReaders.add(logReader);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
             add(tabPane, BorderLayout.CENTER);
         } else {
@@ -138,6 +156,24 @@ public class ErrorMessagePanel extends JPanel {
         }
         JLabel editHintLabel = new JLabel("<html>" + loc + "<br/><br/>" + editMessage + "</html>");
         add(editHintLabel, BorderLayout.SOUTH);
+
+        // Initialize log folder watching
+        logUpdateWorker = new LogUpdateWorker(logFileFolder);
+        PropertyChangeListener logChangeListener = new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                if (evt.getPropertyName() == LogUpdateWorker.CREATED) {
+                    Path newLogPath = (Path)evt.getNewValue();
+                    addNewTab(logFileFolder, newLogPath);
+                }
+                else if (evt.getPropertyName() == LogUpdateWorker.MODIFIED) {
+                    Path changedLogPath = (Path)evt.getNewValue();
+                    updateLog(changedLogPath);
+                }
+            }
+        };
+        logUpdateWorker.addPropertyChangeListener(logChangeListener);
+        logUpdateWorker.execute();
     }
 
     private static void sortLogFiles(List<Path> files) {
@@ -244,5 +280,56 @@ public class ErrorMessagePanel extends JPanel {
         }
 
         return builder.toString();
+    }
+
+    /**
+     * Add a new Tab when there is a new log file
+     * @param logFileFolder log folder
+     * @param newLogPath    path of the new log file
+     */
+    private void addNewTab(Path logFileFolder, Path newLogPath) {
+        logFiles.add(newLogPath);
+        sortLogFiles(logFiles);
+        int index = logFiles.indexOf(newLogPath);
+
+        String tabName = logFileFolder.relativize(newLogPath).toString();
+        final String logFileContent = readLogFileContent(newLogPath);
+        JTextArea logArea = new JTextArea();
+        logArea.setText(logFileContent);
+        textAreas.add(index,logArea);
+        tabPane.insertTab(tabName, null, new JScrollPane(logArea), null, index);
+        tabPane.updateUI();
+
+        File file = newLogPath.toFile();
+        try {
+            RandomAccessFile logReader = new RandomAccessFile(file, "r");
+            logReader.seek(file.length());
+            logReaders.add(index, logReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Update log information
+     * @param changedLogPath path of the changed log file
+     */
+    private void updateLog(Path changedLogPath) {
+        int index = logFiles.indexOf(changedLogPath);
+        if (index != -1) {
+            RandomAccessFile logReader = logReaders.get(index);
+            JTextArea jTextArea = textAreas.get(index);
+            try {
+                String line = logReader.readLine();
+                while (line != null) {
+                    jTextArea.append(line);
+                    jTextArea.append(System.lineSeparator());
+                    line = logReader.readLine();
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        this.updateUI();
     }
 }

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/LogUpdateWorker.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/LogUpdateWorker.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.crashreporter.pages;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+
+import javax.swing.SwingWorker;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.StandardWatchEventKinds;
+
+import java.util.List;
+
+/**
+ * LogUpdateWorker watches log folder change.
+ * It watches change in the background thread, see {@code doInBackground} method.
+ * It processes event in EDT thread, see {@code process} method.
+ */
+public class LogUpdateWorker extends SwingWorker<Void, WatchEvent<Path>> {
+
+    public static final String CREATED = "CREATE_LOG";
+    public static final String MODIFIED = "MODIFIED_LOG";
+
+    private Path directory;
+    private WatchService watchService;
+
+    public LogUpdateWorker(Path directory) {
+        try {
+            this.directory = directory;
+            this.watchService = FileSystems.getDefault().newWatchService();
+            directory.register(watchService, new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE}, SensitivityWatchEventModifier.HIGH);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        for (;;) {
+            // wait for key to be signalled
+            WatchKey key;
+            try {
+                key = watchService.take();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                return null;
+            }
+
+            for (WatchEvent<?> event : key.pollEvents()) {
+                WatchEvent.Kind<?> kind = event.kind();
+                if (kind == StandardWatchEventKinds.OVERFLOW) {
+                    continue;
+                }
+                publish((WatchEvent<Path>) event);
+            }
+
+            // reset key return if directory no longer accessible
+            boolean valid = key.reset();
+            if (!valid) {
+                break;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void process(List<WatchEvent<Path>> chunks) {
+        super.process(chunks);
+        for (WatchEvent<Path> event : chunks) {
+            WatchEvent.Kind<?> kind = event.kind();
+            Path fileName = event.context();
+            Path fileResolvedName = directory.resolve(fileName);
+            if (kind == StandardWatchEventKinds.ENTRY_CREATE) {
+                firePropertyChange(CREATED, null, fileResolvedName);
+            } else if (kind == StandardWatchEventKinds.ENTRY_MODIFY) {
+                firePropertyChange(MODIFIED, null, fileResolvedName);
+            }
+        }
+    }
+}

--- a/cr-core/src/main/resources/i18n/MessagesBundle.properties
+++ b/cr-core/src/main/resources/i18n/MessagesBundle.properties
@@ -1,5 +1,7 @@
 dialogTitle=Crash Reporter
+dialogTitleNonCritical=Issue Reporter
 firstLine=A fatal error occurred
+firstLineNonCritical=Current game log
 editBeforeUpload=NOTE: you can edit the content of the log file before uploading
 viewLog=Log file
 logFileUrl=Log file

--- a/cr-core/src/main/resources/i18n/MessagesBundle.properties
+++ b/cr-core/src/main/resources/i18n/MessagesBundle.properties
@@ -1,7 +1,9 @@
-dialogTitle=Crash Reporter
-dialogTitleNonCritical=Issue Reporter
-firstLine=A fatal error occurred
-firstLineNonCritical=Current game log
+crashTitle=Crash Reporter
+issueTitle=Issue Reporter
+feedbackTitle=Feedback
+firstLineCrash=A fatal error occurred
+firstLineIssue=Current game log
+firstLineFeedback=Thanks for your feedback
 editBeforeUpload=NOTE: you can edit the content of the log file before uploading
 viewLog=Log file
 logFileUrl=Log file

--- a/cr-core/src/test/java/org/terasology/crashreporter/InteractiveTestCases.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/InteractiveTestCases.java
@@ -66,7 +66,7 @@ public final class InteractiveTestCases {
 
             if (!GraphicsEnvironment.isHeadless()) {
                 Path logPath = Paths.get(".");
-                CrashReporter.report(e, logPath,true);
+                CrashReporter.report(e, logPath);
             }
         }
     }

--- a/cr-core/src/test/java/org/terasology/crashreporter/InteractiveTestCases.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/InteractiveTestCases.java
@@ -66,7 +66,7 @@ public final class InteractiveTestCases {
 
             if (!GraphicsEnvironment.isHeadless()) {
                 Path logPath = Paths.get(".");
-                CrashReporter.report(e, logPath);
+                CrashReporter.report(e, logPath,true);
             }
         }
     }


### PR DESCRIPTION
### Contains 
Fix #35, also for issue [MovingBlocks/Terasology#2765](https://github.com/MovingBlocks/CrashReporter/issues/35) and  PR [MovingBlocks/Terasology#2777](https://github.com/MovingBlocks/Terasology/pull/2777)

### What I have done 
![2017-02-08 9 42 09](https://cloud.githubusercontent.com/assets/17897358/22757212/46907308-ee4a-11e6-9f76-5814eb221765.png)

My idea is to add an new parameter `boolean ifCritical` to verify whether the CR in critical mode or not, so there should be some changes in Terasology code when we use CR Class. Please see PR [MovingBlocks/Terasology#2777](https://github.com/MovingBlocks/Terasology/pull/2777) 

### Need Suggestions !
- [ ] There might be another way to distinguish critical mode or non-critical mode. e.g. when we register non-critical CR in the button, we use `new Throwable("Report an error.")` as a throwable parameter. In real crash, the throwable parameter must have differences with  `new Throwable("Report an error.")`, e.g. their messages are different. Using this way we could do less modification in code because we don't need `boolean ifCritical`parameter anymore, but it may make the code less readable. What's your opinion ? or you have a better idea ?  👍 
- [ ] For the part with red underline "Throwable : Report a error", I'm wondering if we need this since we don't have any exceptions in non-critical mode. If we should just delete it or replace it by another phrase ?
- [ ] Just as mentioned in [MovingBlocks/Terasology#2765](https://github.com/MovingBlocks/CrashReporter/issues/35), we think that the CR window might better be a non modal window in order not to lock the game when we open the issue reporter. I've tried just setting the `jDialog` to type `modeless`. It do not lock the game anymore, but it don't update the log information and it can be reopened several times (we can have lots of windows in one time). I will try to get the log update and to make only one CR window appear in one time. Any suggestions are welcomed !!!