### PR TITLE
Version conflict with snowplow in telemetry

### DIFF
--- a/cr-core/build.gradle
+++ b/cr-core/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     compile ('com.google.apis:google-api-services-drive:v2-rev193-1.20.0') {
         // This exclusion avoids a dependency clash against newer versions of Guava in projects using the CR
         exclude module: 'guava-jdk5'
+        // This exclusion avoids a crash when a newer version of jackson is needed in telemetry/snowplow
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
     }
     //compile 'com.google.oauth-client:google-oauth-client-java6:1.19.0'
     //compile 'com.google.oauth-client:google-oauth-client-jetty:1.19.0'


### PR DESCRIPTION
Exclude the jackson in CR-core, and include newer version in engine to test snowplow tracker for telemetry. CR still works.