### PR TITLE
Dependency tweak for when the CR is embedded within a Terasology workspace

### DIFF
--- a/cr-core/build.gradle
+++ b/cr-core/build.gradle
@@ -43,12 +43,13 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.2'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
+    compile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
     testCompile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.21'
 
     testRuntime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
 
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
+
     compile ('com.google.apis:google-api-services-drive:v2-rev193-1.20.0') {
         // This exclusion avoids a dependency clash against newer versions of Guava in projects using the CR
         exclude module: 'guava-jdk5'
@@ -60,6 +61,12 @@ dependencies {
             exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         }
     }
+
+    // But on the other hand to be able to run the unit tests successfully while embedded we still do need this
+    if (rootProject.name == "Terasology") {
+        testCompile group: 'com.google.http-client', name: 'google-http-client-jackson2', version: '1.20.0'
+    }
+
     //compile 'com.google.oauth-client:google-oauth-client-java6:1.19.0'
     //compile 'com.google.oauth-client:google-oauth-client-jetty:1.19.0'
 }


### PR DESCRIPTION
Tiny PR just for doc purposes. Noticed that the CR unit tests would fail when embedded within Terasology, which recently was tweaked to avoid a different dependency issue. Yay dependency hell! This just throws in a dependency at `testCompile` scope for the CR to run its tests from within Terasology and bumps mockito to the same version (which in turn broke some unit tests *within Terasology* when the CR was embedded. Fun)