### PR TITLE
feat: update to use the google drive v3 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
 apply plugin: 'idea'
 
 wrapper {
-    gradleVersion = '6.8.2'
+    gradleVersion = '8.2'
 }
 
 // Using this instead of allprojects allows this project to be embedded yet not affect parent projects

--- a/cr-core/build.gradle
+++ b/cr-core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     implementation group: 'com.google.guava', name: 'guava', version: '19.0'
 
-    implementation ('com.google.apis:google-api-services-drive:v2-rev193-1.20.0') {
+    implementation ('com.google.apis:google-api-services-drive:v3-rev20230610-2.0.0') {
         // This exclusion avoids a dependency clash against newer versions of Guava in projects using the CR
         exclude module: 'guava-jdk5'
 

--- a/cr-core/src/test/java/org/terasology/crashreporter/GoogleDriveConnectorTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/GoogleDriveConnectorTest.java
@@ -4,6 +4,7 @@
 package org.terasology.crashreporter;
 
 import com.google.api.services.drive.model.File;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,7 +14,11 @@ import org.slf4j.LoggerFactory;
 import org.terasology.crashreporter.logic.GoogleDriveConnector;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 
 public class GoogleDriveConnectorTest {
 
@@ -32,7 +37,7 @@ public class GoogleDriveConnectorTest {
     @Test
     public void listingTest() throws IOException {
         for (File f : gdrive.retrieveAllFiles()) {
-            logger.info("Found file: {} - {} bytes: {}", f.getOriginalFilename(), f.getFileSize(),  f.getWebContentLink());
+            logger.info("Found file: {} - {} bytes: {}", f.getOriginalFilename(), f.getSize(), f.getWebContentLink());
         }
     }
 
@@ -43,5 +48,15 @@ public class GoogleDriveConnectorTest {
 
         File bannerTextImage = gdrive.getFileForID(id);
         gdrive.downloadToFile(bannerTextImage, tempFolder, true);
+    }
+
+    @Test
+    public void uploadTest() throws IOException {
+        java.io.File tempFile = testFolder.newFile();
+        Files.write(tempFile.toPath(), Collections.singletonList("This is a test file."), StandardOpenOption.WRITE);
+        try (InputStream stream = Files.newInputStream(tempFile.toPath())) {
+            File uploadedFile = gdrive.uploadFile(stream, tempFile.getName(), true);
+            Assert.assertNotNull(uploadedFile);
+        }
     }
 }

--- a/cr-destsol/build.gradle
+++ b/cr-destsol/build.gradle
@@ -8,6 +8,20 @@ plugins {
     id "idea"
 }
 
+repositories {
+    maven {
+        name "Terasology Artifactory"
+        url "http://artifactory.terasology.org:8081/artifactory/virtual-repo-live"
+        allowInsecureProtocol = true
+    }
+    mavenCentral()
+    maven {
+        name "JBoss Public Maven Repository Group"
+        url "https://repository.jboss.org/nexus/content/repositories/public/"
+        allowInsecureProtocol = true
+    }
+}
+
 dependencies {
     api project(":cr-core")
 }

--- a/cr-terasology/build.gradle
+++ b/cr-terasology/build.gradle
@@ -12,11 +12,13 @@ repositories {
     maven {
         name "Terasology Artifactory"
         url "http://artifactory.terasology.org:8081/artifactory/virtual-repo-live"
+        allowInsecureProtocol = true
     }
     mavenCentral()
     maven {
         name "JBoss Public Maven Repository Group"
         url "https://repository.jboss.org/nexus/content/repositories/public/"
+        allowInsecureProtocol = true
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Contains
This updates the crash reporter to user the newer `v3` Google Drive API. This should hopefully be a bit more future-proof.

### How to test
If you have the Google Drive API set-up with a service account, then you can try adjusting the constants in [`GoogleDriveConnector`](https://github.com/MovingBlocks/CrashReporter/blob/8a781c9983d8de84dbee050b5bf7d98458157fdc/cr-core/src/main/java/org/terasology/crashreporter/logic/GoogleDriveConnector.java#L46-L50) and running the test suite.

### Notes
This depends on #49.