### PR TITLE
build: fixes for cr-destol gradle build and cleanup

### DIFF
--- a/cr-destsol/build.gradle.kts
+++ b/cr-destsol/build.gradle.kts
@@ -8,15 +8,28 @@ plugins {
     idea
 }
 
+// We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    maven {
-        name = "Terasology Artifactory"
-        url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+    mavenCentral {
+        content {
+            // This is first choice for most java dependencies, but assume we'll need to check our
+            // own repository for things from our own organization.
+            // (This is an optimization so gradle doesn't try to find our hundreds of modules in 3rd party repos)
+            excludeGroupByRegex("org.terasology(..+)?")
+        }
     }
-    mavenCentral()
+    // JBoss Maven Repository requried to fetch `org.jpastebin` dependency for CrashReporter
+    // https://developer.jboss.org/docs/DOC-11377
     maven {
         name = "JBoss Public Maven Repository Group"
         url = uri("https://repository.jboss.org/nexus/content/repositories/public/")
+        content {
+            includeModule("org", "jpastebin")
+        }
+    }
+    maven {
+        name = "Terasology Artifactory"
+        url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
     }
 }
 

--- a/cr-destsol/build.gradle.kts
+++ b/cr-destsol/build.gradle.kts
@@ -8,6 +8,18 @@ plugins {
     idea
 }
 
+repositories {
+    maven {
+        name = "Terasology Artifactory"
+        url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+    }
+    mavenCentral()
+    maven {
+        name = "JBoss Public Maven Repository Group"
+        url = uri("https://repository.jboss.org/nexus/content/repositories/public/")
+    }
+}
+
 dependencies {
     api(project(":cr-core"))
 }

--- a/cr-terasology/build.gradle.kts
+++ b/cr-terasology/build.gradle.kts
@@ -8,15 +8,28 @@ plugins {
     idea
 }
 
+// We use both Maven Central and our own Artifactory instance, which contains module builds, extra libs, and so on
 repositories {
-    maven {
-        name = "Terasology Artifactory"
-        url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
+    mavenCentral {
+        content {
+            // This is first choice for most java dependencies, but assume we'll need to check our
+            // own repository for things from our own organization.
+            // (This is an optimization so gradle doesn't try to find our hundreds of modules in 3rd party repos)
+            excludeGroupByRegex("org.terasology(..+)?")
+        }
     }
-    mavenCentral()
+    // JBoss Maven Repository requried to fetch `org.jpastebin` dependency for CrashReporter
+    // https://developer.jboss.org/docs/DOC-11377
     maven {
         name = "JBoss Public Maven Repository Group"
         url = uri("https://repository.jboss.org/nexus/content/repositories/public/")
+        content {
+            includeModule("org", "jpastebin")
+        }
+    }
+    maven {
+        name = "Terasology Artifactory"
+        url = uri("https://artifactory.terasology.io/artifactory/virtual-repo-live")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,17 +1,6 @@
 // Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-// Check to see if CR is embedded within Terasology, if so use nested paths
-println("rootProject for CrashReporter is: " + rootProject.name)
-
-if (rootProject.name == "Terasology") {
-    println("CrashReporter is embedded within Terasology, using nested paths")
-    include(":libs:CrashReporter:cr-core")
-    include(":libs:CrashReporter:cr-destsol")
-    include(":libs:CrashReporter:cr-terasology")
-} else {
-    println("CrashReporter is running standalone so using simple paths for includes")
-    include("cr-core")
-    include("cr-destsol")
-    include("cr-terasology")
-}
+include("cr-core")
+include("cr-destsol")
+include("cr-terasology")


### PR DESCRIPTION
The pull request fixes the `cr-destol` build by adding back the missing `repositories` block. It also removes some obsolete Terasology specific configuration logic from `settings.gradle.kts` that has not been used in a long time, since Terasology moved to using more robust Gradle composite builds.