### PR TITLE
fix(reporter): include every log file in the PasteBin upload

### DIFF
--- a/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
@@ -39,16 +39,20 @@ public final class GlobalProperties {
     public GlobalProperties() {
         String propsUrl = "/crashreporter.properties";
         String defaultPropsUrl = "/crashreporter_defaults.properties";
-        try (InputStream stream = CrashReporter.class.getResourceAsStream(defaultPropsUrl)) {
-            properties.load(stream);
+        loadIfPresent(defaultPropsUrl);
+        // Only cr-core's downstream consumers (cr-terasology, cr-destsol, ...) ship this file -
+        // it's absent when cr-core is used standalone, which getResourceAsStream signals with
+        // null rather than an IOException, so that has to be checked explicitly.
+        loadIfPresent(propsUrl);
+    }
+
+    private void loadIfPresent(String resourceUrl) {
+        try (InputStream stream = CrashReporter.class.getResourceAsStream(resourceUrl)) {
+            if (stream != null) {
+                properties.load(stream);
+            }
         } catch (IOException e) {
-            // this should never go wrong
-            System.err.println("Unable to load default properties");
-        }
-        try (InputStream stream = CrashReporter.class.getResourceAsStream(propsUrl)) {
-            properties.load(stream);
-        } catch (IOException e) {
-            System.err.println("Unable to load " + propsUrl);
+            System.err.println("Unable to load " + resourceUrl);
         }
     }
 

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -231,11 +231,22 @@ public class ErrorMessagePanel extends JPanel {
     }
 
     /**
-     * @return the (edited) log file contents
+     * @return the (edited) contents of every log file/tab, each preceded by a header naming its
+     *         tab - not just the one currently selected. With one file present, the header is
+     *         still included: the alternative (special-casing the single-file case to omit it)
+     *         would make the format depend on how many logs happen to exist, which the uploaded
+     *         text's own reader has no way to tell from the content alone.
      */
     public String getLog() {
-        int idx = tabPane.getSelectedIndex();
-        return idx >= 0 ? textAreas.get(idx).getText() : "";
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < textAreas.size(); i++) {
+            if (i > 0) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("=== ").append(tabPane.getTitleAt(i)).append(" ===").append(System.lineSeparator());
+            builder.append(textAreas.get(i).getText());
+        }
+        return builder.toString();
     }
 
     /**

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/ErrorMessagePanelTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/ErrorMessagePanelTest.java
@@ -1,0 +1,52 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.terasology.crashreporter.CrashReporter;
+import org.terasology.crashreporter.GlobalProperties;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for #53: PasteBin upload only included whichever log tab happened to be
+ * selected, silently dropping every other log file present.
+ */
+class ErrorMessagePanelTest {
+
+    @Test
+    void getLogIncludesEveryLogFileNotJustTheSelectedTab(@TempDir Path logFolder) throws IOException {
+        writeLog(logFolder, "Terasology-init.log", "INIT LOG CONTENT");
+        writeLog(logFolder, "Terasology-menu.log", "MENU LOG CONTENT");
+
+        ErrorMessagePanel panel = new ErrorMessagePanel(new GlobalProperties(), new RuntimeException("boom"),
+                logFolder, CrashReporter.MODE.CRASH_REPORTER);
+
+        String log = panel.getLog();
+        assertTrue(log.contains("INIT LOG CONTENT"), "Expected the init log's content in the combined log, got: " + log);
+        assertTrue(log.contains("MENU LOG CONTENT"), "Expected the menu log's content in the combined log, got: " + log);
+        assertTrue(log.contains("Terasology-init.log"), "Expected a header naming the init log tab, got: " + log);
+        assertTrue(log.contains("Terasology-menu.log"), "Expected a header naming the menu log tab, got: " + log);
+    }
+
+    @Test
+    void getLogStillWorksWithASingleLogFile(@TempDir Path logFolder) throws IOException {
+        writeLog(logFolder, "Terasology.log", "SOLO LOG CONTENT");
+
+        ErrorMessagePanel panel = new ErrorMessagePanel(new GlobalProperties(), new RuntimeException("boom"),
+                logFolder, CrashReporter.MODE.CRASH_REPORTER);
+
+        assertTrue(panel.getLog().contains("SOLO LOG CONTENT"));
+    }
+
+    private static void writeLog(Path folder, String name, String content) throws IOException {
+        Files.write(folder.resolve(name), content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `ErrorMessagePanel.getLog()` only read the currently-selected tab's `JTextArea`. With multiple log files present (e.g. `Terasology-init.log` and `Terasology-menu.log`), whichever tab happened to be selected when "PasteBin" was clicked was the only content that got uploaded - the rest never made it into the report anywhere. Now concatenates every tab's content, each preceded by a header naming it.
- Fixes a latent `NullPointerException` in `GlobalProperties`: `getResourceAsStream()` returns `null` (not an `IOException`) for the optional `crashreporter.properties` override, which `cr-core` itself doesn't ship - only its downstream consumers (`cr-terasology`, `cr-destsol`) do. `Properties.load(null)` threw an NPE uncaught by the existing `catch (IOException)`. This surfaced while adding a real test for the `getLog()` fix, since `cr-core`'s own test classpath has no override file either.

First fix from #53 (5 UI/workflow bugs found in one test pass through the reporter dialog); the tab ordering, blank GitHub issue link, dead forum link, and Discord invite items are separate follow-ups, not addressed here.

## Test plan

- [x] New `ErrorMessagePanelTest` - constructs a real `ErrorMessagePanel` against a temp folder with two log files, asserts both files' content and tab names appear in `getLog()`'s output; a second case covers the single-file path still working.
- [x] `./gradlew build` - clean.

## Related

- Fixes #53 (partially - see follow-ups above).
