### PR TITLE
build: bump wrapper to Gradle 9.7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Bumps the wrapper from 9.6.1 to 9.7.1 (patch release, no build-file changes needed).
- Only `distributionUrl`/`distributionSha256Sum` move. The wrapper jar and `gradlew` scripts are left untouched.

## Test plan

- [x] `./gradlew build --warning-mode=all` - clean, no Gradle-10 deprecation warnings, full test suite passes.

## Related

- None.
