### PR TITLE
fix(reporter): pre-fill the GitHub issue form with a crash summary

### DIFF
--- a/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
@@ -18,6 +18,7 @@ public final class GlobalProperties {
         SUPPORT_FORUM_LINK,
         JOIN_DISCORD_LINK,
         REPORT_ISSUE_LINK,
+        REPORT_ISSUE_TEMPLATE,
 
         RES_BANNER_IMAGE,
         RES_SERVER_ICON,

--- a/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/RootPanel.java
@@ -74,7 +74,13 @@ public class RootPanel extends JPanel {
             }
         });
         pages.add(uploadPanel);
-        pages.add(new FinalActionsPanel(properties, new Supplier<URL>() {
+        pages.add(new FinalActionsPanel(properties, exception, new Supplier<String>() {
+
+            @Override
+            public String get() {
+                return errorMessagePanel.getLog();
+            }
+        }, new Supplier<URL>() {
 
             @Override
             public URL get() {

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -3,6 +3,8 @@
 
 package org.terasology.crashreporter.pages;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -10,13 +12,21 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Builds a pre-filled GitHub issue title/body from a crash: the exception itself (available
- * directly, no parsing needed), plus every other exception found across the crashed process' own
- * log tabs, and the engine version/active module list - the reporter runs in its own JVM (see #52,
- * subprocess isolation) and has no other way to reach any of the log-only information.
+ * Builds a pre-filled GitHub issue title/body from a crash: the exception itself, plus every other
+ * exception found across the crashed process' own log tabs, and the engine version/active module
+ * list - the reporter runs in its own JVM (see #52, subprocess isolation) and has no other way to
+ * reach any of the log-only information.
  * <p>
- * The regexes here mirror two fixed, narrow log lines the engine emits at startup - see
- * {@code TerasologyEngine#logEnvironmentInfo} ({@code TerasologyVersion#toString}'s
+ * On macOS, that subprocess isolation means the in-process {@code Throwable} passed to
+ * {@link #extract} is a best-effort reconstruction from just its class name and message (see
+ * {@code CrashReporter#reconstructThrowable}) - its own stack trace points into the reporter's own
+ * relaunch machinery, not the real crash site. Whenever the crash was also logged in one of the log
+ * tabs (the normal case for an engine-level crash handler), the trace captured from that log text is
+ * the real one and is used instead; the reconstructed exception's own trace is only a fallback for
+ * when nothing better is available.
+ * <p>
+ * The version/module regexes here mirror two fixed, narrow log lines the engine emits at startup -
+ * see {@code TerasologyEngine#logEnvironmentInfo} ({@code TerasologyVersion#toString}'s
  * {@code [buildNumber=..., ..., engineVersion=X, displayVersion=Y]} format) and
  * {@code RegisterMods} ({@code "Activating module: <id>:<version>"}, once per active module).
  * Log formatting is not a published API and can drift; a change there degrades this to a blank
@@ -24,6 +34,7 @@ import java.util.regex.Pattern;
  */
 public final class CrashSummary {
 
+    private static final int MAX_STACK_LINES = 15;
     private static final int MAX_MODULES_LISTED = 30;
     private static final int MAX_TITLE_MESSAGE_LENGTH = 80;
     private static final int MAX_EXCEPTIONS_LISTED = 10;
@@ -41,16 +52,16 @@ public final class CrashSummary {
             "(?m)^([\\w$]+(?:\\.[\\w$]+)+(?:Exception|Error))(:[^\\n]*)?\\n((?:[ \\t]*(?:at |Caused by:)[^\\n]*\\n?)+)");
 
     private final Throwable exception;
-    private final List<String> exceptionRows;
+    private final List<String> exceptionBlocks;
     private final int moreExceptionsCount;
     private final String engineVersion;
     private final String displayVersion;
     private final List<String> activeModules;
 
-    private CrashSummary(Throwable exception, List<String> exceptionRows, int moreExceptionsCount,
+    private CrashSummary(Throwable exception, List<String> exceptionBlocks, int moreExceptionsCount,
                           String engineVersion, String displayVersion, List<String> activeModules) {
         this.exception = exception;
-        this.exceptionRows = exceptionRows;
+        this.exceptionBlocks = exceptionBlocks;
         this.moreExceptionsCount = moreExceptionsCount;
         this.engineVersion = engineVersion;
         this.displayVersion = displayVersion;
@@ -60,67 +71,108 @@ public final class CrashSummary {
     public static CrashSummary extract(Throwable exception, String combinedLogText) {
         String text = combinedLogText != null ? combinedLogText : "";
 
-        List<String> rows = buildExceptionRows(exception, text);
+        List<String> blocks = buildExceptionBlocks(exception, text);
         int moreCount = 0;
-        if (rows.size() > MAX_EXCEPTIONS_LISTED) {
-            moreCount = rows.size() - MAX_EXCEPTIONS_LISTED;
-            rows = new ArrayList<>(rows.subList(0, MAX_EXCEPTIONS_LISTED));
+        if (blocks.size() > MAX_EXCEPTIONS_LISTED) {
+            moreCount = blocks.size() - MAX_EXCEPTIONS_LISTED;
+            blocks = new ArrayList<>(blocks.subList(0, MAX_EXCEPTIONS_LISTED));
         }
 
-        return new CrashSummary(exception, rows, moreCount,
+        return new CrashSummary(exception, blocks, moreCount,
                 firstGroup(ENGINE_VERSION_PATTERN, text), firstGroup(DISPLAY_VERSION_PATTERN, text),
                 extractActiveModules(text));
     }
 
     /**
-     * Builds one row per distinct exception found - the one that triggered this report first
-     * (attributed to whichever log tab also logged it, if any - see {@link #NO_TAB_LABEL}), then
-     * every other exception found across the log tabs, so a crash whose real cause is an earlier
-     * exception logged in a different tab (e.g. during init) isn't left out of the pre-filled issue
-     * just because it wasn't the in-process {@code exception} the reporter happened to be invoked
-     * with.
+     * Builds one Markdown block per distinct exception found - the one that triggered this report
+     * first, then every other exception found across the log tabs - so a crash whose real cause is
+     * an earlier exception logged in a different tab (e.g. during init) isn't left out of the
+     * pre-filled issue just because it wasn't the in-process {@code exception} the reporter happened
+     * to be invoked with.
      */
-    private static List<String> buildExceptionRows(Throwable exception, String combinedLogText) {
+    private static List<String> buildExceptionBlocks(Throwable exception, String combinedLogText) {
         String primaryHeader = exception.toString().trim();
         List<ExceptionEntry> found = findAllExceptions(combinedLogText);
 
-        String primaryTab = null;
+        ExceptionEntry primary = null;
         for (ExceptionEntry entry : found) {
             if (entry.header.equals(primaryHeader)) {
-                primaryTab = entry.tabName;
+                primary = entry;
                 break;
             }
         }
+        // Not logged anywhere - fall back to the exception object's own trace. On macOS that trace
+        // is a best-effort reconstruction (see the class javadoc) rather than the real crash site,
+        // but it's all that's available.
+        if (primary == null) {
+            primary = new ExceptionEntry(null, primaryHeader, framesFromThrowable(exception));
+        }
 
-        List<String> rows = new ArrayList<>();
-        rows.add(formatRow(primaryTab, primaryHeader));
+        List<String> blocks = new ArrayList<>();
+        blocks.add(formatBlock(primary));
         for (ExceptionEntry entry : found) {
             if (entry.header.equals(primaryHeader)) {
                 continue;
             }
-            String row = formatRow(entry.tabName, entry.header);
-            if (!rows.contains(row)) {
-                rows.add(row);
+            String block = formatBlock(entry);
+            if (!blocks.contains(block)) {
+                blocks.add(block);
             }
         }
-        return rows;
+        return blocks;
     }
 
-    private static String formatRow(String tabName, String header) {
-        String label = tabName != null ? tabName : NO_TAB_LABEL;
-        String message = header.length() > MAX_TITLE_MESSAGE_LENGTH
-                ? header.substring(0, MAX_TITLE_MESSAGE_LENGTH - 3) + "..."
-                : header;
-        return "**" + label + "**: `" + message + "`";
+    private static String formatBlock(ExceptionEntry entry) {
+        String label = entry.tabName != null ? entry.tabName : NO_TAB_LABEL;
+        String combined = entry.frames.isEmpty() ? entry.header : entry.header + "\n" + entry.frames;
+        return "**" + label + "**\n\n```\n" + truncateTrace(combined) + "\n```";
+    }
+
+    private static String truncateTrace(String combined) {
+        String[] lines = combined.split("\r?\n");
+        StringBuilder builder = new StringBuilder();
+        int limit = Math.min(lines.length, MAX_STACK_LINES);
+        for (int i = 0; i < limit; i++) {
+            builder.append(lines[i]).append('\n');
+        }
+        if (lines.length > limit) {
+            builder.append("... ").append(lines.length - limit).append(" more line(s) - see the full log\n");
+        }
+        return builder.toString().trim();
+    }
+
+    private static String framesFromThrowable(Throwable exception) {
+        StringWriter sink = new StringWriter();
+        exception.printStackTrace(new PrintWriter(sink));
+        String full = sink.toString();
+        // printStackTrace()'s first line is exception.toString() - already the header - so only the
+        // "at ..."/"Caused by: ..." frames after it are needed here.
+        int newlineIndex = full.indexOf('\n');
+        return newlineIndex >= 0 ? stripTrailingWhitespace(full.substring(newlineIndex + 1)) : "";
+    }
+
+    /**
+     * Like {@link String#trim()} but only at the end - frame lines are indented with a leading tab
+     * ({@code "\tat ..."}), which a plain {@code trim()} would strip from the first line along with
+     * the trailing newline it's actually meant to remove.
+     */
+    private static String stripTrailingWhitespace(String s) {
+        int end = s.length();
+        while (end > 0 && Character.isWhitespace(s.charAt(end - 1))) {
+            end--;
+        }
+        return s.substring(0, end);
     }
 
     private static final class ExceptionEntry {
         private final String tabName;
         private final String header;
+        private final String frames;
 
-        private ExceptionEntry(String tabName, String header) {
+        private ExceptionEntry(String tabName, String header, String frames) {
             this.tabName = tabName;
             this.header = header;
+            this.frames = frames;
         }
     }
 
@@ -154,7 +206,8 @@ public final class CrashSummary {
         Matcher matcher = STACK_TRACE_HEADER_PATTERN.matcher(tabText);
         while (matcher.find()) {
             String header = (matcher.group(1) + (matcher.group(2) != null ? matcher.group(2) : "")).trim();
-            found.add(new ExceptionEntry(tabName, header));
+            String frames = stripTrailingWhitespace(matcher.group(3));
+            found.add(new ExceptionEntry(tabName, header, frames));
         }
     }
 
@@ -193,20 +246,19 @@ public final class CrashSummary {
 
     /**
      * @param pastebinLink the uploaded log link, or {@code null} if the user skipped upload
-     * @return a Markdown issue body: every exception found (one row each, naming the log tab it was
-     *         found in), then environment info, then a link to the full logs
+     * @return a Markdown issue body: every exception found, one labeled code block each (naming the
+     *         log tab it was found in), then environment info, then a link to the full logs
      */
     public String buildBody(URL pastebinLink) {
         StringBuilder body = new StringBuilder();
 
         body.append("### Exceptions\n\n");
-        for (String row : exceptionRows) {
-            body.append("- ").append(row).append('\n');
+        for (String block : exceptionBlocks) {
+            body.append(block).append("\n\n");
         }
         if (moreExceptionsCount > 0) {
-            body.append("- ... ").append(moreExceptionsCount).append(" more - see the full log\n");
+            body.append("... ").append(moreExceptionsCount).append(" more - see the full log\n\n");
         }
-        body.append('\n');
 
         body.append("### Environment\n\n");
         body.append("- Terasology version: ").append(engineVersion.isEmpty() ? "unknown" : engineVersion);

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -38,6 +38,7 @@ public final class CrashSummary {
     private static final int MAX_MODULES_LISTED = 30;
     private static final int MAX_TITLE_MESSAGE_LENGTH = 80;
     private static final int MAX_EXCEPTIONS_LISTED = 10;
+    private static final int CONTEXT_LINES_BEFORE = 5;
     private static final String NO_TAB_LABEL = "this crash";
 
     private static final Pattern ENGINE_VERSION_PATTERN = Pattern.compile("engineVersion=([^,\\]]*)");
@@ -103,9 +104,9 @@ public final class CrashSummary {
         }
         // Not logged anywhere - fall back to the exception object's own trace. On macOS that trace
         // is a best-effort reconstruction (see the class javadoc) rather than the real crash site,
-        // but it's all that's available.
+        // but it's all that's available. There's no log text to pull leading context from either.
         if (primary == null) {
-            primary = new ExceptionEntry(null, primaryHeader, framesFromThrowable(exception));
+            primary = new ExceptionEntry(null, primaryHeader, framesFromThrowable(exception), "");
         }
 
         List<String> blocks = new ArrayList<>();
@@ -125,7 +126,11 @@ public final class CrashSummary {
     private static String formatBlock(ExceptionEntry entry) {
         String label = entry.tabName != null ? entry.tabName : NO_TAB_LABEL;
         String combined = entry.frames.isEmpty() ? entry.header : entry.header + "\n" + entry.frames;
-        return "**" + label + "**\n\n```\n" + truncateTrace(combined) + "\n```";
+        String trace = truncateTrace(combined);
+        // Context isn't part of the trace itself, so it's not subject to truncateTrace()'s
+        // MAX_STACK_LINES cap - a few lines of what led up to the crash shouldn't cost trace detail.
+        String content = entry.context.isEmpty() ? trace : entry.context + "\n" + trace;
+        return "**" + label + "**\n\n```\n" + content + "\n```";
     }
 
     private static String truncateTrace(String combined) {
@@ -168,11 +173,13 @@ public final class CrashSummary {
         private final String tabName;
         private final String header;
         private final String frames;
+        private final String context;
 
-        private ExceptionEntry(String tabName, String header, String frames) {
+        private ExceptionEntry(String tabName, String header, String frames, String context) {
             this.tabName = tabName;
             this.header = header;
             this.frames = frames;
+            this.context = context;
         }
     }
 
@@ -192,7 +199,16 @@ public final class CrashSummary {
                 break;
             }
             tabName = tabMatcher.group(1);
+            // tabMatcher.end() lands right after "===", before that line's own terminator - skip it
+            // too, so each tab's text starts at its real first content line instead of with a blank
+            // artifact line (which precedingLines() would otherwise count as logged context).
             tabStart = tabMatcher.end();
+            if (tabStart < combinedLogText.length() && combinedLogText.charAt(tabStart) == '\r') {
+                tabStart++;
+            }
+            if (tabStart < combinedLogText.length() && combinedLogText.charAt(tabStart) == '\n') {
+                tabStart++;
+            }
         }
         // No "=== tab ===" headers at all - a single combined-log caller (e.g. a direct test) rather
         // than ErrorMessagePanel#getLog(); scan the whole text with no tab attribution.
@@ -207,8 +223,31 @@ public final class CrashSummary {
         while (matcher.find()) {
             String header = (matcher.group(1) + (matcher.group(2) != null ? matcher.group(2) : "")).trim();
             String frames = stripTrailingWhitespace(matcher.group(3));
-            found.add(new ExceptionEntry(tabName, header, frames));
+            String context = precedingLines(tabText, matcher.start(), CONTEXT_LINES_BEFORE);
+            found.add(new ExceptionEntry(tabName, header, frames, context));
         }
+    }
+
+    /**
+     * @return up to {@code maxLines} lines of whatever was logged right before {@code beforeIndex} in
+     *         {@code text} - what led up to a crash is often as useful for diagnosing it as the trace
+     *         itself, and it's only available here (the reporter's own {@link #exception} carries no
+     *         log context of its own).
+     */
+    private static String precedingLines(String text, int beforeIndex, int maxLines) {
+        String[] lines = text.substring(0, beforeIndex).split("\r?\n", -1);
+        int end = lines.length;
+        // A trailing empty element only ever means the substring ended in a newline - i.e. the line
+        // right before the match, not a real blank log line - so it isn't context to show.
+        if (end > 0 && lines[end - 1].isEmpty()) {
+            end--;
+        }
+        int start = Math.max(0, end - maxLines);
+        StringBuilder builder = new StringBuilder();
+        for (int i = start; i < end; i++) {
+            builder.append(lines[i]).append('\n');
+        }
+        return stripTrailingWhitespace(builder.toString());
     }
 
     private static String firstGroup(Pattern pattern, String text) {

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -29,31 +29,41 @@ public final class CrashSummary {
     private static final int MAX_STACK_LINES = 15;
     private static final int MAX_MODULES_LISTED = 30;
     private static final int MAX_TITLE_MESSAGE_LENGTH = 80;
+    private static final int MAX_OTHER_EXCEPTIONS_LISTED = 10;
 
     private static final Pattern ENGINE_VERSION_PATTERN = Pattern.compile("engineVersion=([^,\\]]*)");
     private static final Pattern DISPLAY_VERSION_PATTERN = Pattern.compile("displayVersion=([^,\\]]*)");
     private static final Pattern ACTIVE_MODULE_PATTERN = Pattern.compile("Activating module: (\\S+:\\S+)");
+    private static final Pattern LOG_TAB_PATTERN = Pattern.compile("(?m)^=== (.*) ===$");
+    // A log-formatted stack trace: a "some.FullyQualified.NameException[: message]" header line
+    // immediately followed by one or more "at ..."/"Caused by: ..." frame lines - the shape every
+    // JVM logging framework prints a Throwable in (Logback's %ex, java.util.logging, a raw
+    // printStackTrace()), regardless of which class emits it.
+    private static final Pattern STACK_TRACE_HEADER_PATTERN = Pattern.compile(
+            "(?m)^([\\w$]+(?:\\.[\\w$]+)+(?:Exception|Error))(:[^\\n]*)?\\n((?:[ \\t]*(?:at |Caused by:)[^\\n]*\\n?)+)");
 
     private final Throwable exception;
     private final String stackTraceExtract;
     private final String engineVersion;
     private final String displayVersion;
     private final List<String> activeModules;
+    private final List<String> otherExceptions;
 
     private CrashSummary(Throwable exception, String stackTraceExtract, String engineVersion,
-                          String displayVersion, List<String> activeModules) {
+                          String displayVersion, List<String> activeModules, List<String> otherExceptions) {
         this.exception = exception;
         this.stackTraceExtract = stackTraceExtract;
         this.engineVersion = engineVersion;
         this.displayVersion = displayVersion;
         this.activeModules = activeModules;
+        this.otherExceptions = otherExceptions;
     }
 
     public static CrashSummary extract(Throwable exception, String combinedLogText) {
         String text = combinedLogText != null ? combinedLogText : "";
         return new CrashSummary(exception, extractStackTrace(exception),
                 firstGroup(ENGINE_VERSION_PATTERN, text), firstGroup(DISPLAY_VERSION_PATTERN, text),
-                extractActiveModules(text));
+                extractActiveModules(text), extractOtherExceptions(text, exception));
     }
 
     private static String extractStackTrace(Throwable exception) {
@@ -86,6 +96,56 @@ public final class CrashSummary {
             }
         }
         return modules;
+    }
+
+    /**
+     * Scans every log tab (not just the one that triggered this report - see {@link #buildBody}) for
+     * other stack traces, so a crash whose real cause is an earlier exception logged in a different
+     * tab (e.g. during init) isn't left out of the pre-filled issue just because it wasn't the
+     * in-process {@code exception} the reporter happened to be invoked with.
+     *
+     * @return "tab name: header line" for each distinct exception found, skipping {@code exception}'s
+     *         own header line - that one is already covered by {@link #stackTraceExtract}.
+     */
+    private static List<String> extractOtherExceptions(String combinedLogText, Throwable exception) {
+        String primaryHeader = exception.toString().trim();
+        List<String> found = new ArrayList<>();
+
+        Matcher tabMatcher = LOG_TAB_PATTERN.matcher(combinedLogText);
+        int tabStart = -1;
+        String tabName = null;
+        while (true) {
+            boolean hasNext = tabMatcher.find();
+            int nextStart = hasNext ? tabMatcher.start() : combinedLogText.length();
+            if (tabName != null) {
+                collectExceptionHeaders(combinedLogText.substring(tabStart, nextStart), tabName, primaryHeader, found);
+            }
+            if (!hasNext) {
+                break;
+            }
+            tabName = tabMatcher.group(1);
+            tabStart = tabMatcher.end();
+        }
+        // No "=== tab ===" headers at all - a single combined-log caller (e.g. a direct test) rather
+        // than ErrorMessagePanel#getLog(); scan the whole text as one unnamed tab.
+        if (tabName == null) {
+            collectExceptionHeaders(combinedLogText, "log", primaryHeader, found);
+        }
+        return found;
+    }
+
+    private static void collectExceptionHeaders(String tabText, String tabName, String primaryHeader, List<String> found) {
+        Matcher matcher = STACK_TRACE_HEADER_PATTERN.matcher(tabText);
+        while (matcher.find()) {
+            String header = (matcher.group(1) + (matcher.group(2) != null ? matcher.group(2) : "")).trim();
+            if (header.equals(primaryHeader)) {
+                continue;
+            }
+            String entry = tabName + ": " + header;
+            if (!found.contains(entry)) {
+                found.add(entry);
+            }
+        }
     }
 
     /**
@@ -132,6 +192,17 @@ public final class CrashSummary {
             }
             if (activeModules.size() > shown) {
                 body.append("  - ... ").append(activeModules.size() - shown).append(" more\n");
+            }
+        }
+
+        if (!otherExceptions.isEmpty()) {
+            body.append("\n### Other exceptions found in logs\n\n");
+            int shown = Math.min(otherExceptions.size(), MAX_OTHER_EXCEPTIONS_LISTED);
+            for (int i = 0; i < shown; i++) {
+                body.append("- `").append(otherExceptions.get(i)).append("`\n");
+            }
+            if (otherExceptions.size() > shown) {
+                body.append("- ... ").append(otherExceptions.size() - shown).append(" more - see the full log\n");
             }
         }
 

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -1,0 +1,143 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds a pre-filled GitHub issue title/body from a crash: the exception itself (available
+ * directly, no parsing needed), plus the engine version and active module list, which only exist
+ * in the crashed process' own log output - the reporter runs in its own JVM (see #52, subprocess
+ * isolation) and has no other way to reach them.
+ * <p>
+ * The regexes here mirror two fixed, narrow log lines the engine emits at startup - see
+ * {@code TerasologyEngine#logEnvironmentInfo} ({@code TerasologyVersion#toString}'s
+ * {@code [buildNumber=..., ..., engineVersion=X, displayVersion=Y]} format) and
+ * {@code RegisterMods} ({@code "Activating module: <id>:<version>"}, once per active module).
+ * Log formatting is not a published API and can drift; a change there degrades this to a blank
+ * "unknown"/empty-list extract rather than failing the report itself.
+ */
+public final class CrashSummary {
+
+    private static final int MAX_STACK_LINES = 15;
+    private static final int MAX_MODULES_LISTED = 30;
+    private static final int MAX_TITLE_MESSAGE_LENGTH = 80;
+
+    private static final Pattern ENGINE_VERSION_PATTERN = Pattern.compile("engineVersion=([^,\\]]*)");
+    private static final Pattern DISPLAY_VERSION_PATTERN = Pattern.compile("displayVersion=([^,\\]]*)");
+    private static final Pattern ACTIVE_MODULE_PATTERN = Pattern.compile("Activating module: (\\S+:\\S+)");
+
+    private final Throwable exception;
+    private final String stackTraceExtract;
+    private final String engineVersion;
+    private final String displayVersion;
+    private final List<String> activeModules;
+
+    private CrashSummary(Throwable exception, String stackTraceExtract, String engineVersion,
+                          String displayVersion, List<String> activeModules) {
+        this.exception = exception;
+        this.stackTraceExtract = stackTraceExtract;
+        this.engineVersion = engineVersion;
+        this.displayVersion = displayVersion;
+        this.activeModules = activeModules;
+    }
+
+    public static CrashSummary extract(Throwable exception, String combinedLogText) {
+        String text = combinedLogText != null ? combinedLogText : "";
+        return new CrashSummary(exception, extractStackTrace(exception),
+                firstGroup(ENGINE_VERSION_PATTERN, text), firstGroup(DISPLAY_VERSION_PATTERN, text),
+                extractActiveModules(text));
+    }
+
+    private static String extractStackTrace(Throwable exception) {
+        StringWriter sink = new StringWriter();
+        exception.printStackTrace(new PrintWriter(sink));
+        String[] lines = sink.toString().split("\r?\n");
+        StringBuilder builder = new StringBuilder();
+        int limit = Math.min(lines.length, MAX_STACK_LINES);
+        for (int i = 0; i < limit; i++) {
+            builder.append(lines[i]).append('\n');
+        }
+        if (lines.length > limit) {
+            builder.append("... ").append(lines.length - limit).append(" more line(s) - see the full log\n");
+        }
+        return builder.toString().trim();
+    }
+
+    private static String firstGroup(Pattern pattern, String text) {
+        Matcher matcher = pattern.matcher(text);
+        return matcher.find() ? matcher.group(1).trim() : "";
+    }
+
+    private static List<String> extractActiveModules(String text) {
+        List<String> modules = new ArrayList<>();
+        Matcher matcher = ACTIVE_MODULE_PATTERN.matcher(text);
+        while (matcher.find()) {
+            String module = matcher.group(1);
+            if (!modules.contains(module)) {
+                modules.add(module);
+            }
+        }
+        return modules;
+    }
+
+    /**
+     * @return a short, single-line issue title: the exception's simple class name, plus a
+     *         truncated message if it has one.
+     */
+    public String buildTitle() {
+        StringBuilder title = new StringBuilder("Crash: ").append(exception.getClass().getSimpleName());
+        String message = exception.getLocalizedMessage();
+        if (message != null && !message.trim().isEmpty()) {
+            String trimmed = message.length() > MAX_TITLE_MESSAGE_LENGTH
+                    ? message.substring(0, MAX_TITLE_MESSAGE_LENGTH - 3) + "..."
+                    : message;
+            title.append(": ").append(trimmed);
+        }
+        return title.toString();
+    }
+
+    /**
+     * @param pastebinLink the uploaded log link, or {@code null} if the user skipped upload
+     * @return a Markdown issue body with the exception extract, environment info, and a link to
+     *         the full logs
+     */
+    public String buildBody(URL pastebinLink) {
+        StringBuilder body = new StringBuilder();
+        body.append("### Exception\n\n```\n").append(stackTraceExtract).append("\n```\n\n");
+
+        body.append("### Environment\n\n");
+        body.append("- Terasology version: ").append(engineVersion.isEmpty() ? "unknown" : engineVersion);
+        if (!displayVersion.isEmpty()) {
+            body.append(" (").append(displayVersion).append(')');
+        }
+        body.append('\n');
+        body.append("- OS: ").append(System.getProperty("os.name")).append(' ')
+                .append(System.getProperty("os.version")).append(" (").append(System.getProperty("os.arch")).append(")\n");
+        body.append("- Active modules:");
+        if (activeModules.isEmpty()) {
+            body.append(" none found in logs\n");
+        } else {
+            body.append('\n');
+            int shown = Math.min(activeModules.size(), MAX_MODULES_LISTED);
+            for (int i = 0; i < shown; i++) {
+                body.append("  - ").append(activeModules.get(i)).append('\n');
+            }
+            if (activeModules.size() > shown) {
+                body.append("  - ... ").append(activeModules.size() - shown).append(" more\n");
+            }
+        }
+
+        body.append("\n### Full logs\n\n");
+        body.append(pastebinLink != null ? "[PasteBin](" + pastebinLink + ")\n" : "(not uploaded)\n");
+
+        return body.toString();
+    }
+}

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -7,7 +7,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -325,5 +327,54 @@ public final class CrashSummary {
         body.append(pastebinLink != null ? "[PasteBin](" + pastebinLink + ")\n" : "(not uploaded)\n");
 
         return body.toString();
+    }
+
+    /**
+     * @param pastebinLink the uploaded log link, or {@code null} if the user skipped upload
+     * @return field ID to value for the issue form named by
+     *         {@link org.terasology.crashreporter.GlobalProperties.KEY#REPORT_ISSUE_TEMPLATE} - only
+     *         meaningful when a downstream app has configured one (see
+     *         {@link GitHubIssueLinkBuilder#build(String, String, String, Map)}); the IDs here match
+     *         Terasology's own {@code crash-bug-report.yml}. Fields with nothing extractable are
+     *         omitted so the user's own blank field is left for them to fill in, rather than being
+     *         pre-filled with something misleading like "unknown".
+     */
+    public Map<String, String> buildIssueFormFields(URL pastebinLink) {
+        Map<String, String> fields = new LinkedHashMap<>();
+
+        if (!engineVersion.isEmpty()) {
+            String version = displayVersion.isEmpty() ? engineVersion : engineVersion + " (" + displayVersion + ")";
+            fields.put("terasology_version", version);
+        }
+        fields.put("operating_system", System.getProperty("os.name") + " " + System.getProperty("os.version")
+                + " (" + System.getProperty("os.arch") + ")");
+        fields.put("java_version", System.getProperty("java.version"));
+
+        StringBuilder actual = new StringBuilder();
+        for (String block : exceptionBlocks) {
+            actual.append(block).append("\n\n");
+        }
+        if (moreExceptionsCount > 0) {
+            actual.append("... ").append(moreExceptionsCount).append(" more - see the full log\n");
+        }
+        fields.put("actual_behavior", actual.toString().trim());
+
+        if (pastebinLink != null) {
+            fields.put("log_details", "[PasteBin](" + pastebinLink + ")");
+        }
+
+        if (!activeModules.isEmpty()) {
+            StringBuilder modules = new StringBuilder("Active modules:\n");
+            int shown = Math.min(activeModules.size(), MAX_MODULES_LISTED);
+            for (int i = 0; i < shown; i++) {
+                modules.append("- ").append(activeModules.get(i)).append('\n');
+            }
+            if (activeModules.size() > shown) {
+                modules.append("- ... ").append(activeModules.size() - shown).append(" more\n");
+            }
+            fields.put("additional_context", modules.toString().trim());
+        }
+
+        return fields;
     }
 }

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/CrashSummary.java
@@ -3,8 +3,6 @@
 
 package org.terasology.crashreporter.pages;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,9 +11,9 @@ import java.util.regex.Pattern;
 
 /**
  * Builds a pre-filled GitHub issue title/body from a crash: the exception itself (available
- * directly, no parsing needed), plus the engine version and active module list, which only exist
- * in the crashed process' own log output - the reporter runs in its own JVM (see #52, subprocess
- * isolation) and has no other way to reach them.
+ * directly, no parsing needed), plus every other exception found across the crashed process' own
+ * log tabs, and the engine version/active module list - the reporter runs in its own JVM (see #52,
+ * subprocess isolation) and has no other way to reach any of the log-only information.
  * <p>
  * The regexes here mirror two fixed, narrow log lines the engine emits at startup - see
  * {@code TerasologyEngine#logEnvironmentInfo} ({@code TerasologyVersion#toString}'s
@@ -26,10 +24,10 @@ import java.util.regex.Pattern;
  */
 public final class CrashSummary {
 
-    private static final int MAX_STACK_LINES = 15;
     private static final int MAX_MODULES_LISTED = 30;
     private static final int MAX_TITLE_MESSAGE_LENGTH = 80;
-    private static final int MAX_OTHER_EXCEPTIONS_LISTED = 10;
+    private static final int MAX_EXCEPTIONS_LISTED = 10;
+    private static final String NO_TAB_LABEL = "this crash";
 
     private static final Pattern ENGINE_VERSION_PATTERN = Pattern.compile("engineVersion=([^,\\]]*)");
     private static final Pattern DISPLAY_VERSION_PATTERN = Pattern.compile("displayVersion=([^,\\]]*)");
@@ -43,42 +41,121 @@ public final class CrashSummary {
             "(?m)^([\\w$]+(?:\\.[\\w$]+)+(?:Exception|Error))(:[^\\n]*)?\\n((?:[ \\t]*(?:at |Caused by:)[^\\n]*\\n?)+)");
 
     private final Throwable exception;
-    private final String stackTraceExtract;
+    private final List<String> exceptionRows;
+    private final int moreExceptionsCount;
     private final String engineVersion;
     private final String displayVersion;
     private final List<String> activeModules;
-    private final List<String> otherExceptions;
 
-    private CrashSummary(Throwable exception, String stackTraceExtract, String engineVersion,
-                          String displayVersion, List<String> activeModules, List<String> otherExceptions) {
+    private CrashSummary(Throwable exception, List<String> exceptionRows, int moreExceptionsCount,
+                          String engineVersion, String displayVersion, List<String> activeModules) {
         this.exception = exception;
-        this.stackTraceExtract = stackTraceExtract;
+        this.exceptionRows = exceptionRows;
+        this.moreExceptionsCount = moreExceptionsCount;
         this.engineVersion = engineVersion;
         this.displayVersion = displayVersion;
         this.activeModules = activeModules;
-        this.otherExceptions = otherExceptions;
     }
 
     public static CrashSummary extract(Throwable exception, String combinedLogText) {
         String text = combinedLogText != null ? combinedLogText : "";
-        return new CrashSummary(exception, extractStackTrace(exception),
+
+        List<String> rows = buildExceptionRows(exception, text);
+        int moreCount = 0;
+        if (rows.size() > MAX_EXCEPTIONS_LISTED) {
+            moreCount = rows.size() - MAX_EXCEPTIONS_LISTED;
+            rows = new ArrayList<>(rows.subList(0, MAX_EXCEPTIONS_LISTED));
+        }
+
+        return new CrashSummary(exception, rows, moreCount,
                 firstGroup(ENGINE_VERSION_PATTERN, text), firstGroup(DISPLAY_VERSION_PATTERN, text),
-                extractActiveModules(text), extractOtherExceptions(text, exception));
+                extractActiveModules(text));
     }
 
-    private static String extractStackTrace(Throwable exception) {
-        StringWriter sink = new StringWriter();
-        exception.printStackTrace(new PrintWriter(sink));
-        String[] lines = sink.toString().split("\r?\n");
-        StringBuilder builder = new StringBuilder();
-        int limit = Math.min(lines.length, MAX_STACK_LINES);
-        for (int i = 0; i < limit; i++) {
-            builder.append(lines[i]).append('\n');
+    /**
+     * Builds one row per distinct exception found - the one that triggered this report first
+     * (attributed to whichever log tab also logged it, if any - see {@link #NO_TAB_LABEL}), then
+     * every other exception found across the log tabs, so a crash whose real cause is an earlier
+     * exception logged in a different tab (e.g. during init) isn't left out of the pre-filled issue
+     * just because it wasn't the in-process {@code exception} the reporter happened to be invoked
+     * with.
+     */
+    private static List<String> buildExceptionRows(Throwable exception, String combinedLogText) {
+        String primaryHeader = exception.toString().trim();
+        List<ExceptionEntry> found = findAllExceptions(combinedLogText);
+
+        String primaryTab = null;
+        for (ExceptionEntry entry : found) {
+            if (entry.header.equals(primaryHeader)) {
+                primaryTab = entry.tabName;
+                break;
+            }
         }
-        if (lines.length > limit) {
-            builder.append("... ").append(lines.length - limit).append(" more line(s) - see the full log\n");
+
+        List<String> rows = new ArrayList<>();
+        rows.add(formatRow(primaryTab, primaryHeader));
+        for (ExceptionEntry entry : found) {
+            if (entry.header.equals(primaryHeader)) {
+                continue;
+            }
+            String row = formatRow(entry.tabName, entry.header);
+            if (!rows.contains(row)) {
+                rows.add(row);
+            }
         }
-        return builder.toString().trim();
+        return rows;
+    }
+
+    private static String formatRow(String tabName, String header) {
+        String label = tabName != null ? tabName : NO_TAB_LABEL;
+        String message = header.length() > MAX_TITLE_MESSAGE_LENGTH
+                ? header.substring(0, MAX_TITLE_MESSAGE_LENGTH - 3) + "..."
+                : header;
+        return "**" + label + "**: `" + message + "`";
+    }
+
+    private static final class ExceptionEntry {
+        private final String tabName;
+        private final String header;
+
+        private ExceptionEntry(String tabName, String header) {
+            this.tabName = tabName;
+            this.header = header;
+        }
+    }
+
+    private static List<ExceptionEntry> findAllExceptions(String combinedLogText) {
+        List<ExceptionEntry> found = new ArrayList<>();
+
+        Matcher tabMatcher = LOG_TAB_PATTERN.matcher(combinedLogText);
+        int tabStart = -1;
+        String tabName = null;
+        while (true) {
+            boolean hasNext = tabMatcher.find();
+            int nextStart = hasNext ? tabMatcher.start() : combinedLogText.length();
+            if (tabName != null) {
+                collectExceptionHeaders(combinedLogText.substring(tabStart, nextStart), tabName, found);
+            }
+            if (!hasNext) {
+                break;
+            }
+            tabName = tabMatcher.group(1);
+            tabStart = tabMatcher.end();
+        }
+        // No "=== tab ===" headers at all - a single combined-log caller (e.g. a direct test) rather
+        // than ErrorMessagePanel#getLog(); scan the whole text with no tab attribution.
+        if (tabName == null) {
+            collectExceptionHeaders(combinedLogText, null, found);
+        }
+        return found;
+    }
+
+    private static void collectExceptionHeaders(String tabText, String tabName, List<ExceptionEntry> found) {
+        Matcher matcher = STACK_TRACE_HEADER_PATTERN.matcher(tabText);
+        while (matcher.find()) {
+            String header = (matcher.group(1) + (matcher.group(2) != null ? matcher.group(2) : "")).trim();
+            found.add(new ExceptionEntry(tabName, header));
+        }
     }
 
     private static String firstGroup(Pattern pattern, String text) {
@@ -99,56 +176,6 @@ public final class CrashSummary {
     }
 
     /**
-     * Scans every log tab (not just the one that triggered this report - see {@link #buildBody}) for
-     * other stack traces, so a crash whose real cause is an earlier exception logged in a different
-     * tab (e.g. during init) isn't left out of the pre-filled issue just because it wasn't the
-     * in-process {@code exception} the reporter happened to be invoked with.
-     *
-     * @return "tab name: header line" for each distinct exception found, skipping {@code exception}'s
-     *         own header line - that one is already covered by {@link #stackTraceExtract}.
-     */
-    private static List<String> extractOtherExceptions(String combinedLogText, Throwable exception) {
-        String primaryHeader = exception.toString().trim();
-        List<String> found = new ArrayList<>();
-
-        Matcher tabMatcher = LOG_TAB_PATTERN.matcher(combinedLogText);
-        int tabStart = -1;
-        String tabName = null;
-        while (true) {
-            boolean hasNext = tabMatcher.find();
-            int nextStart = hasNext ? tabMatcher.start() : combinedLogText.length();
-            if (tabName != null) {
-                collectExceptionHeaders(combinedLogText.substring(tabStart, nextStart), tabName, primaryHeader, found);
-            }
-            if (!hasNext) {
-                break;
-            }
-            tabName = tabMatcher.group(1);
-            tabStart = tabMatcher.end();
-        }
-        // No "=== tab ===" headers at all - a single combined-log caller (e.g. a direct test) rather
-        // than ErrorMessagePanel#getLog(); scan the whole text as one unnamed tab.
-        if (tabName == null) {
-            collectExceptionHeaders(combinedLogText, "log", primaryHeader, found);
-        }
-        return found;
-    }
-
-    private static void collectExceptionHeaders(String tabText, String tabName, String primaryHeader, List<String> found) {
-        Matcher matcher = STACK_TRACE_HEADER_PATTERN.matcher(tabText);
-        while (matcher.find()) {
-            String header = (matcher.group(1) + (matcher.group(2) != null ? matcher.group(2) : "")).trim();
-            if (header.equals(primaryHeader)) {
-                continue;
-            }
-            String entry = tabName + ": " + header;
-            if (!found.contains(entry)) {
-                found.add(entry);
-            }
-        }
-    }
-
-    /**
      * @return a short, single-line issue title: the exception's simple class name, plus a
      *         truncated message if it has one.
      */
@@ -166,12 +193,20 @@ public final class CrashSummary {
 
     /**
      * @param pastebinLink the uploaded log link, or {@code null} if the user skipped upload
-     * @return a Markdown issue body with the exception extract, environment info, and a link to
-     *         the full logs
+     * @return a Markdown issue body: every exception found (one row each, naming the log tab it was
+     *         found in), then environment info, then a link to the full logs
      */
     public String buildBody(URL pastebinLink) {
         StringBuilder body = new StringBuilder();
-        body.append("### Exception\n\n```\n").append(stackTraceExtract).append("\n```\n\n");
+
+        body.append("### Exceptions\n\n");
+        for (String row : exceptionRows) {
+            body.append("- ").append(row).append('\n');
+        }
+        if (moreExceptionsCount > 0) {
+            body.append("- ... ").append(moreExceptionsCount).append(" more - see the full log\n");
+        }
+        body.append('\n');
 
         body.append("### Environment\n\n");
         body.append("- Terasology version: ").append(engineVersion.isEmpty() ? "unknown" : engineVersion);
@@ -192,17 +227,6 @@ public final class CrashSummary {
             }
             if (activeModules.size() > shown) {
                 body.append("  - ... ").append(activeModules.size() - shown).append(" more\n");
-            }
-        }
-
-        if (!otherExceptions.isEmpty()) {
-            body.append("\n### Other exceptions found in logs\n\n");
-            int shown = Math.min(otherExceptions.size(), MAX_OTHER_EXCEPTIONS_LISTED);
-            for (int i = 0; i < shown; i++) {
-                body.append("- `").append(otherExceptions.get(i)).append("`\n");
-            }
-            if (otherExceptions.size() > shown) {
-                body.append("- ... ").append(otherExceptions.size() - shown).append(" more - see the full log\n");
             }
         }
 

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/FinalActionsPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/FinalActionsPanel.java
@@ -97,8 +97,18 @@ public class FinalActionsPanel extends JPanel {
             @Override
             public void actionPerformed(ActionEvent e) {
                 CrashSummary summary = CrashSummary.extract(exception, logTextSupplier.get());
-                String link = GitHubIssueLinkBuilder.build(properties.get(KEY.REPORT_ISSUE_LINK),
-                        summary.buildTitle(), summary.buildBody(uploadedFile.get()));
+                String baseUrl = properties.get(KEY.REPORT_ISSUE_LINK);
+                String template = properties.get(KEY.REPORT_ISSUE_TEMPLATE);
+                String link;
+                if (template != null && !template.isEmpty()) {
+                    // The downstream app has its own issue *form* - land the summary in its real
+                    // fields instead of overwriting the whole thing with a bespoke body.
+                    link = GitHubIssueLinkBuilder.build(baseUrl, template, summary.buildTitle(),
+                            summary.buildIssueFormFields(uploadedFile.get()));
+                } else {
+                    link = GitHubIssueLinkBuilder.build(baseUrl, summary.buildTitle(),
+                            summary.buildBody(uploadedFile.get()));
+                }
                 openInBrowser(link);
                 pageComplete = true;
                 firePropertyChange("pageComplete", !pageComplete, pageComplete);

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/FinalActionsPanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/FinalActionsPanel.java
@@ -39,6 +39,10 @@ public class FinalActionsPanel extends JPanel {
 
     private static final long serialVersionUID = 2639334979749507943L;
 
+    private final Throwable exception;
+
+    private final Supplier<String> logTextSupplier;
+
     private final Supplier<URL> uploadedFile;
 
     private final JTextArea linkText;
@@ -47,8 +51,11 @@ public class FinalActionsPanel extends JPanel {
 
     private boolean pageComplete;
 
-    public FinalActionsPanel(GlobalProperties properties, Supplier<URL> uploadedFile) {
+    public FinalActionsPanel(GlobalProperties properties, Throwable exception, Supplier<String> logTextSupplier,
+                              Supplier<URL> uploadedFile) {
 
+        this.exception = exception;
+        this.logTextSupplier = logTextSupplier;
         this.uploadedFile = uploadedFile;
 
         setLayout(new BorderLayout(0, 10));
@@ -89,7 +96,10 @@ public class FinalActionsPanel extends JPanel {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                openInBrowser(properties.get(KEY.REPORT_ISSUE_LINK));
+                CrashSummary summary = CrashSummary.extract(exception, logTextSupplier.get());
+                String link = GitHubIssueLinkBuilder.build(properties.get(KEY.REPORT_ISSUE_LINK),
+                        summary.buildTitle(), summary.buildBody(uploadedFile.get()));
+                openInBrowser(link);
                 pageComplete = true;
                 firePropertyChange("pageComplete", !pageComplete, pageComplete);
             }

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilder.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilder.java
@@ -1,0 +1,31 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * Builds a GitHub new-issue URL pre-filled via the {@code title}/{@code body} query parameters
+ * GitHub's issue-creation form accepts.
+ */
+public final class GitHubIssueLinkBuilder {
+
+    private GitHubIssueLinkBuilder() {
+    }
+
+    public static String build(String baseUrl, String title, String body) {
+        String query = "title=" + encode(title) + "&body=" + encode(body);
+        return baseUrl + (baseUrl.contains("?") ? "&" : "?") + query;
+    }
+
+    private static String encode(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 is a standard charset every JVM implementation is required to support.
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilder.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilder.java
@@ -5,10 +5,15 @@ package org.terasology.crashreporter.pages;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Map;
 
 /**
- * Builds a GitHub new-issue URL pre-filled via the {@code title}/{@code body} query parameters
- * GitHub's issue-creation form accepts.
+ * Builds a GitHub new-issue URL, pre-filled either via the classic {@code title}/{@code body} query
+ * parameters (works against any repo, regardless of what issue templates it has - the safe default),
+ * or, when a downstream app has one, via an issue *form*'s own field IDs (see
+ * {@link org.terasology.crashreporter.GlobalProperties.KEY#REPORT_ISSUE_TEMPLATE}) - a
+ * {@code template=} query parameter plus one parameter per field ID, landing the crash summary in
+ * the repo's own real template instead of overwriting it with a bespoke body.
  */
 public final class GitHubIssueLinkBuilder {
 
@@ -16,7 +21,32 @@ public final class GitHubIssueLinkBuilder {
     }
 
     public static String build(String baseUrl, String title, String body) {
+        if (baseUrl == null) {
+            return null;
+        }
         String query = "title=" + encode(title) + "&body=" + encode(body);
+        return baseUrl + (baseUrl.contains("?") ? "&" : "?") + query;
+    }
+
+    /**
+     * @param template the issue form's filename (e.g. {@code "crash-bug-report.yml"}), as it appears
+     *         under {@code .github/ISSUE_TEMPLATE/} in the target repo
+     * @param fields field ID to value - entries with a {@code null}/empty value are omitted, leaving
+     *         that field for the user to fill in themselves rather than pre-filling it blank
+     */
+    public static String build(String baseUrl, String template, String title, Map<String, String> fields) {
+        if (baseUrl == null) {
+            return null;
+        }
+        StringBuilder query = new StringBuilder("template=").append(encode(template))
+                .append("&title=").append(encode(title));
+        for (Map.Entry<String, String> field : fields.entrySet()) {
+            String value = field.getValue();
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
+            query.append('&').append(field.getKey()).append('=').append(encode(value));
+        }
         return baseUrl + (baseUrl.contains("?") ? "&" : "?") + query;
     }
 

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -96,10 +96,11 @@ class CrashSummaryTest {
     // triggered the report, but only the in-process exception ever made it into the pre-filled
     // issue - an exception logged in a different tab (e.g. an earlier init-time failure) was
     // silently left out even though it was right there in the combined text. All exceptions - the
-    // primary one and every other one found - are listed together, one row each, before
+    // primary one and every other one found - are listed together, one labeled code block each
+    // (full trace, not just a one-line header - a real fix needs the actual trace), before
     // "### Environment", not split across two separate sections.
     @Test
-    void bodyListsExceptionsFoundInOtherLogTabsAsARowNamingTheTab() {
+    void bodyListsExceptionsFoundInOtherLogTabsWithTheirFullTraceNamingTheTab() {
         String combinedLog = "=== Terasology-init.log ===\n" + LOG_TEXT
                 + "\n=== Terasology-game.log ===\n"
                 + "10:10:05.123 [main] ERROR o.t.e.core.TerasologyEngine - Uncaught exception in main loop\n"
@@ -110,8 +111,9 @@ class CrashSummaryTest {
         String body = summary.buildBody(null);
 
         assertTrue(body.contains("### Exceptions"), "Expected a single unified exceptions section, got: " + body);
-        assertTrue(body.contains("**Terasology-game.log**: `java.lang.NullPointerException: world was null`"),
-                "Expected the other tab's exception as its own row naming the tab, got: " + body);
+        assertTrue(body.contains("**Terasology-game.log**\n\n```\njava.lang.NullPointerException: world was null\n"
+                        + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n```"),
+                "Expected the other tab's exception as its own labeled block with the full trace, got: " + body);
         int exceptionsIndex = body.indexOf("### Exceptions");
         int environmentIndex = body.indexOf("### Environment");
         assertTrue(exceptionsIndex >= 0 && environmentIndex > exceptionsIndex,
@@ -122,7 +124,9 @@ class CrashSummaryTest {
     void bodyAttributesThePrimaryExceptionToItsOwnTabInsteadOfListingItTwice() {
         RuntimeException primary = new RuntimeException("boom");
         // The crash is very often also logged (by the crashed process itself) in one of its own
-        // log tabs - that's the same exception, not another one, and must not be listed twice.
+        // log tabs - that's the same exception, not another one, and must not be listed twice. It's
+        // also the *real* trace (see the class javadoc on macOS reconstruction), so it must be used
+        // in preference to the exception object's own (possibly fake) trace.
         String combinedLog = "=== Terasology-game.log ===\n"
                 + primary + "\n"
                 + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n";
@@ -130,18 +134,24 @@ class CrashSummaryTest {
         CrashSummary summary = CrashSummary.extract(primary, combinedLog);
         String body = summary.buildBody(null);
 
-        assertTrue(body.contains("**Terasology-game.log**: `java.lang.RuntimeException: boom`"),
-                "Expected the primary exception's row attributed to the tab it was found in, got: " + body);
-        int rows = body.split("\n- \\*\\*", -1).length - 1;
-        assertEquals(1, rows, "Expected exactly one row - the primary exception must not also be listed as an \"other\" one: " + body);
+        assertTrue(body.contains("**Terasology-game.log**\n\n```\njava.lang.RuntimeException: boom\n"
+                        + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n```"),
+                "Expected the primary exception's block attributed to the tab it was found in, using that tab's real trace, got: "
+                        + body);
+        int blocks = body.split("\\*\\*Terasology-game\\.log\\*\\*", -1).length - 1;
+        assertEquals(1, blocks, "Expected exactly one block - the primary exception must not also be listed as an \"other\" one: "
+                + body);
     }
 
     @Test
-    void bodyAttributesThePrimaryExceptionToThisCrashWhenNotFoundInAnyTab() {
-        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+    void bodyFallsBackToTheExceptionsOwnTraceWhenNotFoundInAnyTab() {
+        RuntimeException primary = new RuntimeException("boom");
+        CrashSummary summary = CrashSummary.extract(primary, LOG_TEXT);
         String body = summary.buildBody(null);
 
-        assertTrue(body.contains("**this crash**: `java.lang.RuntimeException: boom`"),
-                "Expected a fallback label when the exception isn't found in any log tab, got: " + body);
+        assertTrue(body.contains("**this crash**\n\n```\njava.lang.RuntimeException: boom\n"),
+                "Expected a fallback label and the exception's own trace when it isn't found in any log tab, got: " + body);
+        assertTrue(body.contains(CrashSummaryTest.class.getName()),
+                "Expected this test's own stack frame in the fallback trace, got: " + body);
     }
 }

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -95,9 +95,11 @@ class CrashSummaryTest {
     // Regression: ErrorMessagePanel#getLog() combines every log tab, not just the one that
     // triggered the report, but only the in-process exception ever made it into the pre-filled
     // issue - an exception logged in a different tab (e.g. an earlier init-time failure) was
-    // silently left out even though it was right there in the combined text.
+    // silently left out even though it was right there in the combined text. All exceptions - the
+    // primary one and every other one found - are listed together, one row each, before
+    // "### Environment", not split across two separate sections.
     @Test
-    void bodyListsExceptionsFoundInOtherLogTabs() {
+    void bodyListsExceptionsFoundInOtherLogTabsAsARowNamingTheTab() {
         String combinedLog = "=== Terasology-init.log ===\n" + LOG_TEXT
                 + "\n=== Terasology-game.log ===\n"
                 + "10:10:05.123 [main] ERROR o.t.e.core.TerasologyEngine - Uncaught exception in main loop\n"
@@ -107,13 +109,17 @@ class CrashSummaryTest {
         CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), combinedLog);
         String body = summary.buildBody(null);
 
-        assertTrue(body.contains("### Other exceptions found in logs"), "Expected a section listing it, got: " + body);
-        assertTrue(body.contains("Terasology-game.log: java.lang.NullPointerException: world was null"),
-                "Expected the other tab's exception attributed to its tab, got: " + body);
+        assertTrue(body.contains("### Exceptions"), "Expected a single unified exceptions section, got: " + body);
+        assertTrue(body.contains("**Terasology-game.log**: `java.lang.NullPointerException: world was null`"),
+                "Expected the other tab's exception as its own row naming the tab, got: " + body);
+        int exceptionsIndex = body.indexOf("### Exceptions");
+        int environmentIndex = body.indexOf("### Environment");
+        assertTrue(exceptionsIndex >= 0 && environmentIndex > exceptionsIndex,
+                "Expected \"### Exceptions\" before \"### Environment\", got: " + body);
     }
 
     @Test
-    void bodyDoesNotDuplicateThePrimaryExceptionAsAnOtherException() {
+    void bodyAttributesThePrimaryExceptionToItsOwnTabInsteadOfListingItTwice() {
         RuntimeException primary = new RuntimeException("boom");
         // The crash is very often also logged (by the crashed process itself) in one of its own
         // log tabs - that's the same exception, not another one, and must not be listed twice.
@@ -124,15 +130,18 @@ class CrashSummaryTest {
         CrashSummary summary = CrashSummary.extract(primary, combinedLog);
         String body = summary.buildBody(null);
 
-        assertFalse(body.contains("### Other exceptions found in logs"),
-                "The primary exception's own log entry must not be listed as an \"other\" exception, got: " + body);
+        assertTrue(body.contains("**Terasology-game.log**: `java.lang.RuntimeException: boom`"),
+                "Expected the primary exception's row attributed to the tab it was found in, got: " + body);
+        int rows = body.split("\n- \\*\\*", -1).length - 1;
+        assertEquals(1, rows, "Expected exactly one row - the primary exception must not also be listed as an \"other\" one: " + body);
     }
 
     @Test
-    void bodyOmitsTheOtherExceptionsSectionWhenThereAreNone() {
+    void bodyAttributesThePrimaryExceptionToThisCrashWhenNotFoundInAnyTab() {
         CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
         String body = summary.buildBody(null);
 
-        assertFalse(body.contains("### Other exceptions found in logs"), "Expected no such section, got: " + body);
+        assertTrue(body.contains("**this crash**: `java.lang.RuntimeException: boom`"),
+                "Expected a fallback label when the exception isn't found in any log tab, got: " + body);
     }
 }

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -91,4 +91,48 @@ class CrashSummaryTest {
         assertFalse(body.contains("null"), "A skipped upload must not leak the literal string \"null\" into the body: " + body);
         assertTrue(body.contains("not uploaded"), "Expected a note that upload was skipped, got: " + body);
     }
+
+    // Regression: ErrorMessagePanel#getLog() combines every log tab, not just the one that
+    // triggered the report, but only the in-process exception ever made it into the pre-filled
+    // issue - an exception logged in a different tab (e.g. an earlier init-time failure) was
+    // silently left out even though it was right there in the combined text.
+    @Test
+    void bodyListsExceptionsFoundInOtherLogTabs() {
+        String combinedLog = "=== Terasology-init.log ===\n" + LOG_TEXT
+                + "\n=== Terasology-game.log ===\n"
+                + "10:10:05.123 [main] ERROR o.t.e.core.TerasologyEngine - Uncaught exception in main loop\n"
+                + "java.lang.NullPointerException: world was null\n"
+                + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n";
+
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), combinedLog);
+        String body = summary.buildBody(null);
+
+        assertTrue(body.contains("### Other exceptions found in logs"), "Expected a section listing it, got: " + body);
+        assertTrue(body.contains("Terasology-game.log: java.lang.NullPointerException: world was null"),
+                "Expected the other tab's exception attributed to its tab, got: " + body);
+    }
+
+    @Test
+    void bodyDoesNotDuplicateThePrimaryExceptionAsAnOtherException() {
+        RuntimeException primary = new RuntimeException("boom");
+        // The crash is very often also logged (by the crashed process itself) in one of its own
+        // log tabs - that's the same exception, not another one, and must not be listed twice.
+        String combinedLog = "=== Terasology-game.log ===\n"
+                + primary + "\n"
+                + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n";
+
+        CrashSummary summary = CrashSummary.extract(primary, combinedLog);
+        String body = summary.buildBody(null);
+
+        assertFalse(body.contains("### Other exceptions found in logs"),
+                "The primary exception's own log entry must not be listed as an \"other\" exception, got: " + body);
+    }
+
+    @Test
+    void bodyOmitsTheOtherExceptionsSectionWhenThereAreNone() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        String body = summary.buildBody(null);
+
+        assertFalse(body.contains("### Other exceptions found in logs"), "Expected no such section, got: " + body);
+    }
 }

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -1,0 +1,94 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for #53 item 3: "Report Issue" opened a blank GitHub form instead of one
+ * pre-filled with the crash summary.
+ */
+class CrashSummaryTest {
+
+    private static final String LOG_TEXT =
+            "10:00:00.000 [main] INFO  o.t.e.version.TerasologyVersion - "
+                    + "[buildNumber=42, buildId=42, buildTag=Terasology-42, buildUrl=, jobName=Terasology/engine/develop, "
+                    + "dateTime=2026-08-20, displayVersion=Aeternum, engineVersion=5.4.0-SNAPSHOT]\n"
+                    + "10:00:00.100 [main] INFO  o.t.e.core.TerasologyEngine - OS: Linux, arch: amd64, version: 6.12.85\n"
+                    + "10:00:01.000 [main] INFO  o.t.e.core.modes.loadProcesses.RegisterMods - Activating module: engine:5.4.0-SNAPSHOT\n"
+                    + "10:00:01.010 [main] INFO  o.t.e.core.modes.loadProcesses.RegisterMods - Activating module: CoreAssets:2.4.0\n"
+                    + "10:00:01.020 [main] INFO  o.t.e.core.modes.loadProcesses.RegisterMods - Activating module: CoreAssets:2.4.0\n";
+
+    @Test
+    void extractsEngineAndDisplayVersion() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        String body = summary.buildBody(null);
+
+        assertTrue(body.contains("5.4.0-SNAPSHOT"), "Expected the engine version in the body, got: " + body);
+        assertTrue(body.contains("Aeternum"), "Expected the display version in the body, got: " + body);
+    }
+
+    @Test
+    void extractsActiveModulesAndDeduplicates() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        String body = summary.buildBody(null);
+
+        assertTrue(body.contains("engine:5.4.0-SNAPSHOT"), "Expected engine module, got: " + body);
+        // Occurs twice in the log (duplicate "Activating module" line) - should appear once in the body.
+        int occurrences = body.split("CoreAssets:2\\.4\\.0", -1).length - 1;
+        assertEquals(1, occurrences, "Expected the duplicate module line deduplicated, got: " + body);
+    }
+
+    @Test
+    void missingVersionAndModulesDegradeGracefullyInsteadOfFailing() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), "no relevant lines here");
+        String body = summary.buildBody(null);
+
+        assertTrue(body.contains("unknown"), "Expected a fallback for a missing version, got: " + body);
+        assertTrue(body.contains("none found in logs"), "Expected a fallback for an empty module list, got: " + body);
+    }
+
+    @Test
+    void titleUsesExceptionClassAndMessage() {
+        CrashSummary summary = CrashSummary.extract(new IllegalStateException("world was null"), LOG_TEXT);
+
+        assertEquals("Crash: IllegalStateException: world was null", summary.buildTitle());
+    }
+
+    @Test
+    void bodyIncludesTheExceptionExtract() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("kaboom"), LOG_TEXT);
+        String body = summary.buildBody(null);
+
+        assertTrue(body.contains("kaboom"), "Expected the exception message in the body, got: " + body);
+        assertTrue(body.contains("RuntimeException"), "Expected the exception type in the body, got: " + body);
+    }
+
+    @Test
+    void bodyIncludesThePastebinLinkWhenUploaded() throws MalformedURLException {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        URL link = new URL("https://pastebin.com/abc123");
+
+        String body = summary.buildBody(link);
+
+        assertTrue(body.contains("https://pastebin.com/abc123"), "Expected the PasteBin link in the body, got: " + body);
+    }
+
+    @Test
+    void bodyNotesWhenUploadWasSkipped() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+
+        String body = summary.buildBody(null);
+
+        assertFalse(body.contains("null"), "A skipped upload must not leak the literal string \"null\" into the body: " + body);
+        assertTrue(body.contains("not uploaded"), "Expected a note that upload was skipped, got: " + body);
+    }
+}

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -111,9 +111,12 @@ class CrashSummaryTest {
         String body = summary.buildBody(null);
 
         assertTrue(body.contains("### Exceptions"), "Expected a single unified exceptions section, got: " + body);
-        assertTrue(body.contains("**Terasology-game.log**\n\n```\njava.lang.NullPointerException: world was null\n"
+        assertTrue(body.contains("**Terasology-game.log**\n\n```\n"
+                        + "10:10:05.123 [main] ERROR o.t.e.core.TerasologyEngine - Uncaught exception in main loop\n"
+                        + "java.lang.NullPointerException: world was null\n"
                         + "\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n```"),
-                "Expected the other tab's exception as its own labeled block with the full trace, got: " + body);
+                "Expected the other tab's exception as its own labeled block, with the line logged right before it and the full "
+                        + "trace, got: " + body);
         int exceptionsIndex = body.indexOf("### Exceptions");
         int environmentIndex = body.indexOf("### Environment");
         assertTrue(exceptionsIndex >= 0 && environmentIndex > exceptionsIndex,
@@ -141,6 +144,25 @@ class CrashSummaryTest {
         int blocks = body.split("\\*\\*Terasology-game\\.log\\*\\*", -1).length - 1;
         assertEquals(1, blocks, "Expected exactly one block - the primary exception must not also be listed as an \"other\" one: "
                 + body);
+    }
+
+    @Test
+    void bodyIncludesOnlyTheLastFiveLinesLoggedBeforeTheException() {
+        StringBuilder combinedLog = new StringBuilder("=== Terasology-game.log ===\n");
+        for (int i = 1; i <= 8; i++) {
+            combinedLog.append("log line ").append(i).append('\n');
+        }
+        combinedLog.append("java.lang.NullPointerException: world was null\n")
+                .append("\tat org.terasology.engine.core.TerasologyEngine.run(TerasologyEngine.java:200)\n");
+
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), combinedLog.toString());
+        String body = summary.buildBody(null);
+
+        assertFalse(body.contains("log line 1\n") || body.contains("log line 2\n") || body.contains("log line 3\n"),
+                "Expected only the last 5 lines of context, not all 8, got: " + body);
+        assertTrue(body.contains("log line 4\nlog line 5\nlog line 6\nlog line 7\nlog line 8\n"
+                        + "java.lang.NullPointerException: world was null"),
+                "Expected the last 5 lines directly before the exception's header, got: " + body);
     }
 
     @Test

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/CrashSummaryTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -175,5 +177,56 @@ class CrashSummaryTest {
                 "Expected a fallback label and the exception's own trace when it isn't found in any log tab, got: " + body);
         assertTrue(body.contains(CrashSummaryTest.class.getName()),
                 "Expected this test's own stack frame in the fallback trace, got: " + body);
+    }
+
+    // buildIssueFormFields() feeds GitHubIssueLinkBuilder's template-based overload (see
+    // GitHubIssueLinkBuilderTest) - used instead of buildBody() when a downstream app has configured
+    // REPORT_ISSUE_TEMPLATE, landing the summary in that issue form's own fields.
+    @Test
+    void issueFormFieldsIncludeVersionOsAndTheExceptionBlocks() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        Map<String, String> fields = summary.buildIssueFormFields(null);
+
+        assertEquals("5.4.0-SNAPSHOT (Aeternum)", fields.get("terasology_version"));
+        assertTrue(fields.get("operating_system").contains(System.getProperty("os.name")), fields.get("operating_system"));
+        assertEquals(System.getProperty("java.version"), fields.get("java_version"));
+        assertTrue(fields.get("actual_behavior").contains("RuntimeException: boom"), fields.get("actual_behavior"));
+    }
+
+    @Test
+    void issueFormFieldsOmitVersionWhenNotFoundInsteadOfSayingUnknown() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), "no relevant lines here");
+        Map<String, String> fields = summary.buildIssueFormFields(null);
+
+        // Unlike buildBody()'s "unknown" fallback, an omitted field is left blank in the actual issue
+        // form for the user to fill in themselves - "unknown" pre-filled into a real form field would
+        // read as if the reporter deliberately couldn't tell, not as an untouched field.
+        assertNull(fields.get("terasology_version"), "Expected no terasology_version entry, got: " + fields);
+    }
+
+    @Test
+    void issueFormFieldsOmitLogDetailsWhenUploadWasSkipped() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        Map<String, String> fields = summary.buildIssueFormFields(null);
+
+        assertNull(fields.get("log_details"), "Expected no log_details entry when nothing was uploaded, got: " + fields);
+    }
+
+    @Test
+    void issueFormFieldsIncludeThePastebinLinkWhenUploaded() throws MalformedURLException {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        URL link = new URL("https://pastebin.com/abc123");
+
+        Map<String, String> fields = summary.buildIssueFormFields(link);
+
+        assertTrue(fields.get("log_details").contains("https://pastebin.com/abc123"), fields.get("log_details"));
+    }
+
+    @Test
+    void issueFormFieldsIncludeActiveModulesUnderAdditionalContext() {
+        CrashSummary summary = CrashSummary.extract(new RuntimeException("boom"), LOG_TEXT);
+        Map<String, String> fields = summary.buildIssueFormFields(null);
+
+        assertTrue(fields.get("additional_context").contains("engine:5.4.0-SNAPSHOT"), fields.get("additional_context"));
     }
 }

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilderTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilderTest.java
@@ -5,10 +5,23 @@ package org.terasology.crashreporter.pages;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GitHubIssueLinkBuilderTest {
+
+    @Test
+    void returnsNullWhenBaseUrlIsNotConfigured() {
+        // REPORT_ISSUE_LINK is only set by downstream apps (cr-terasology, cr-destsol, ...), not by
+        // cr-core's own defaults - build() must not silently produce a broken "null?title=..." link.
+        assertNull(GitHubIssueLinkBuilder.build(null, "t", "b"));
+        assertNull(GitHubIssueLinkBuilder.build(null, "template.yml", "t", new LinkedHashMap<>()));
+    }
 
     @Test
     void appendsTitleAndBodyAsQueryParameters() {
@@ -33,5 +46,34 @@ class GitHubIssueLinkBuilderTest {
         String link = GitHubIssueLinkBuilder.build("https://example.com/issues/new?template=bug", "t", "b");
 
         assertEquals("https://example.com/issues/new?template=bug&title=t&body=b", link);
+    }
+
+    @Test
+    void formBuildAppendsTemplateTitleAndEachFieldAsItsOwnQueryParameter() {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("terasology_version", "5.4.0-SNAPSHOT");
+        fields.put("operating_system", "Mac OS X");
+
+        String link = GitHubIssueLinkBuilder.build("https://github.com/MovingBlocks/Terasology/issues/new",
+                "crash-bug-report.yml", "Crash: NullPointerException", fields);
+
+        assertTrue(link.contains("template=crash-bug-report.yml"), link);
+        assertTrue(link.contains("title=Crash%3A+NullPointerException"), link);
+        assertTrue(link.contains("terasology_version=5.4.0-SNAPSHOT"), link);
+        assertTrue(link.contains("operating_system=Mac+OS+X"), link);
+    }
+
+    @Test
+    void formBuildOmitsFieldsWithNoValueInsteadOfPreFillingThemBlank() {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("terasology_version", "");
+        fields.put("java_version", null);
+        fields.put("operating_system", "Linux");
+
+        String link = GitHubIssueLinkBuilder.build("https://example.com/issues/new", "crash-bug-report.yml", "t", fields);
+
+        assertFalse(link.contains("terasology_version="), link);
+        assertFalse(link.contains("java_version="), link);
+        assertTrue(link.contains("operating_system=Linux"), link);
     }
 }

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilderTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/GitHubIssueLinkBuilderTest.java
@@ -1,0 +1,37 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitHubIssueLinkBuilderTest {
+
+    @Test
+    void appendsTitleAndBodyAsQueryParameters() {
+        String link = GitHubIssueLinkBuilder.build("https://github.com/MovingBlocks/Terasology/issues/new",
+                "Crash: NullPointerException", "some body text");
+
+        assertTrue(link.startsWith("https://github.com/MovingBlocks/Terasology/issues/new?"));
+        assertTrue(link.contains("title=Crash%3A+NullPointerException"), link);
+        assertTrue(link.contains("body=some+body+text"), link);
+    }
+
+    @Test
+    void encodesSpecialCharactersInTitleAndBody() {
+        String link = GitHubIssueLinkBuilder.build("https://example.com/issues/new", "a & b", "line1\nline2");
+
+        assertTrue(link.contains("title=a+%26+b"), link);
+        assertTrue(link.contains("body=line1%0Aline2"), link);
+    }
+
+    @Test
+    void usesAmpersandWhenBaseUrlAlreadyHasAQueryString() {
+        String link = GitHubIssueLinkBuilder.build("https://example.com/issues/new?template=bug", "t", "b");
+
+        assertEquals("https://example.com/issues/new?template=bug&title=t&body=b", link);
+    }
+}

--- a/cr-terasology/src/main/resources/crashreporter.properties
+++ b/cr-terasology/src/main/resources/crashreporter.properties
@@ -1,5 +1,6 @@
 SUPPORT_FORUM_LINK=http://forum.terasology.org/forum/support.20/
 REPORT_ISSUE_LINK=https://github.com/MovingBlocks/Terasology/issues/new
+REPORT_ISSUE_TEMPLATE=crash-bug-report.yml
 JOIN_DISCORD_LINK=https://discord.gg/terasology
 
 RES_BANNER_IMAGE=icons/banner.jpg


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

"Report Issue" just opened `REPORT_ISSUE_LINK` as-is - a bare `https://github.com/.../issues/new`, always blank, discarding everything the dialog already knows about the crash.

`CrashSummary` extracts, from the exception and the crashed process' own log output (the reporter runs in its own JVM per #52's subprocess isolation, so there's no other way to reach engine-version/module info):

- **Every exception found** - one labeled block each (full trace, capped at 15 lines, plus the 5 log lines logged right before it), naming the log tab it was found in. The one that triggered the report is always first, attributed to whichever tab also logged it if any (otherwise labeled "this crash"); every other exception found across the log tabs follows, so a crash whose real cause is an earlier exception logged in a different tab (e.g. during init) isn't left out.

  On macOS the crash reporter always relaunches in a subprocess (`requiresProcessIsolation()`), which reconstructs the exception from just its class name and message - its own stack trace points into the reporter's own relaunch machinery, not the real crash site. Whenever the triggering exception was also logged in a tab, the trace captured from that log text is used instead, since it's the real one.
- **Engine version + active modules** - extracted via regex against two fixed lines `TerasologyEngine` already emits at startup.
- **OS + Java version** - read directly via `System.getProperty`.
- **The uploaded PasteBin link**, when the user uploaded one.

**How it reaches GitHub:** [@BenjaminAmos noted](https://github.com/MovingBlocks/CrashReporter/pull/58#issuecomment-5380220338) this shouldn't invent its own body format when Terasology already has a `crash-bug-report` template, and suggested converting it to an issue *form* so fields could be pre-populated individually. [MovingBlocks/Terasology#5390](https://github.com/MovingBlocks/Terasology/pull/5390) does that conversion. So:

- New `GlobalProperties.KEY.REPORT_ISSUE_TEMPLATE` - when a downstream app sets it (`cr-terasology` now does, to `crash-bug-report.yml`), `CrashSummary.buildIssueFormFields()` + a new `GitHubIssueLinkBuilder.build(baseUrl, template, title, fields)` overload build a `template=`+per-field-ID query, landing the summary in that form's real "Terasology Version"/"Operating System"/"Java Version"/"What actually happened"/"Log details"/"Additional Infos" fields instead of overwriting the whole issue.
- Apps without a configured template (`cr-destsol`, standalone `cr-core`) keep the original generic `buildTitle()`/`buildBody()` title+body fallback unchanged - the field IDs a configured template targets are inherently tied to whichever form that specific downstream repo defines, so this can never be `cr-core`'s unconditional default.

Both `CrashSummary` and `GitHubIssueLinkBuilder` are plain, dependency-free classes with no Swing dependency, so they're covered directly by unit tests without a headless UI harness.

Second fix from #53 (item 3 of 5); log tab ordering, the dead forum link, and the Discord invite are still open follow-ups.

## Test plan

- [x] `CrashSummaryTest` - version/display-version extraction, module dedup, graceful fallback, title formatting, exception blocks (full trace + context lines) for both the triggering exception and others found in other tabs, PasteBin link handling, and `buildIssueFormFields()`'s per-field extraction/omission.
- [x] `GitHubIssueLinkBuilderTest` - query-param encoding, `null` when `REPORT_ISSUE_LINK` isn't configured, the template+fields overload's query building and its omission of empty fields.
- [x] `./gradlew build` - clean.
- [x] Manually verified live: clicked "File an issue on GitHub" in the running dialog - the crash summary landed in the real `crash-bug-report.yml` form fields (Terasology Version, Operating System, Java Version, What actually happened, etc.), not a blank/fallback issue.

## Related

- Third item toward #53.
- Includes what was previously #67 (multi-tab exception listing), folded in here.
- MovingBlocks/Terasology#5390 (the issue-form conversion this depends on for `cr-terasology`).
