### PR TITLE
fix(reporter): sort log tabs alphabetically instead of by creation time

### DIFF
--- a/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/GlobalProperties.java
@@ -39,16 +39,20 @@ public final class GlobalProperties {
     public GlobalProperties() {
         String propsUrl = "/crashreporter.properties";
         String defaultPropsUrl = "/crashreporter_defaults.properties";
-        try (InputStream stream = CrashReporter.class.getResourceAsStream(defaultPropsUrl)) {
-            properties.load(stream);
+        loadIfPresent(defaultPropsUrl);
+        // Only cr-core's downstream consumers (cr-terasology, cr-destsol, ...) ship this file -
+        // it's absent when cr-core is used standalone, which getResourceAsStream signals with
+        // null rather than an IOException, so that has to be checked explicitly.
+        loadIfPresent(propsUrl);
+    }
+
+    private void loadIfPresent(String resourceUrl) {
+        try (InputStream stream = CrashReporter.class.getResourceAsStream(resourceUrl)) {
+            if (stream != null) {
+                properties.load(stream);
+            }
         } catch (IOException e) {
-            // this should never go wrong
-            System.err.println("Unable to load default properties");
-        }
-        try (InputStream stream = CrashReporter.class.getResourceAsStream(propsUrl)) {
-            properties.load(stream);
-        } catch (IOException e) {
-            System.err.println("Unable to load " + propsUrl);
+            System.err.println("Unable to load " + resourceUrl);
         }
     }
 

--- a/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/pages/ErrorMessagePanel.java
@@ -35,7 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -163,24 +162,24 @@ public class ErrorMessagePanel extends JPanel {
         logUpdateWorker.execute();
     }
 
+    /**
+     * Alphabetical by filename, not creation time (see #53 item 1): creation-time order looked
+     * arbitrary to users - two log files from one session sort as "newest first", which is
+     * neither the order they were written in nor the order their names suggest. Alphabetical is
+     * deterministic and, for Terasology's own naming (e.g. {@code Terasology-init.log} before
+     * {@code Terasology-menu.log}), happens to match session order too.
+     */
     private static void sortLogFiles(List<Path> files) {
         files.sort(new Comparator<Path>() {
 
             @Override
             public int compare(Path p0, Path p1) {
-                try {
-                    BasicFileAttributes attr0 = Files.readAttributes(p0, BasicFileAttributes.class);
-                    BasicFileAttributes attr1 = Files.readAttributes(p1, BasicFileAttributes.class);
-                    FileTime time0 = attr0.creationTime();
-                    FileTime time1 = attr1.creationTime();
-                    return time0.compareTo(time1);
-                } catch (Exception e) {
-                    // ignore silently
-                    return 0;
-                }
+                String name0 = p0.getFileName().toString();
+                String name1 = p1.getFileName().toString();
+                return name0.compareToIgnoreCase(name1);
             }
 
-        }.reversed());  // invert sort order
+        });
     }
 
     @Override
@@ -244,6 +243,18 @@ public class ErrorMessagePanel extends JPanel {
     public Path getLogFile() {
         int idx = tabPane.getSelectedIndex();
         return idx >= 0 ? logFiles.get(idx) : null;
+    }
+
+    /**
+     * @return the tab titles (filenames relative to the log folder) in the order they're
+     *         displayed - see {@link #sortLogFiles}.
+     */
+    public List<String> getTabTitles() {
+        List<String> titles = Lists.newArrayListWithCapacity(tabPane.getTabCount());
+        for (int i = 0; i < tabPane.getTabCount(); i++) {
+            titles.add(tabPane.getTitleAt(i));
+        }
+        return titles;
     }
 
     private static String readLogFileContent(Path logFile) {

--- a/cr-core/src/test/java/org/terasology/crashreporter/pages/ErrorMessagePanelTabOrderTest.java
+++ b/cr-core/src/test/java/org/terasology/crashreporter/pages/ErrorMessagePanelTabOrderTest.java
@@ -1,0 +1,45 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.crashreporter.pages;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.terasology.crashreporter.CrashReporter;
+import org.terasology.crashreporter.GlobalProperties;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for #53 item 1: log tabs sorted by file creation time (newest first) instead of
+ * alphabetically, which read as arbitrary/broken with more than one log file present.
+ */
+class ErrorMessagePanelTabOrderTest {
+
+    @Test
+    void tabsAreOrderedAlphabeticallyRegardlessOfCreationOrder(@TempDir Path logFolder) throws IOException, InterruptedException {
+        // Written out of alphabetical order, with a real gap between creation times so a
+        // creation-time-based sort (the old behavior) would disagree with alphabetical order.
+        writeLog(logFolder, "Terasology-menu.log", "MENU");
+        Thread.sleep(10);
+        writeLog(logFolder, "Terasology-init.log", "INIT");
+
+        ErrorMessagePanel panel = new ErrorMessagePanel(new GlobalProperties(), new RuntimeException("boom"),
+                logFolder, CrashReporter.MODE.CRASH_REPORTER);
+
+        List<String> titles = panel.getTabTitles();
+        assertEquals(Arrays.asList("Terasology-init.log", "Terasology-menu.log"), titles,
+                "Expected tabs in alphabetical order regardless of which file was created first, got: " + titles);
+    }
+
+    private static void writeLog(Path folder, String name, String content) throws IOException {
+        Files.write(folder.resolve(name), content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `sortLogFiles()` sorted by file creation time, reversed (newest first). With two log files from one session (`Terasology-init.log`, `Terasology-menu.log`) that reads as arbitrary - neither the order they were written in nor the order their names suggest - rather than a deliberate choice, per the original issue's own framing. Sorting by filename instead is deterministic and, for Terasology's own log naming, happens to match session order too.
- Also carries the `GlobalProperties` NPE guard from #56 - needed just to construct `GlobalProperties()` at all in `cr-core`'s own test classpath, same reasoning as there. Will collapse to a no-op merge once #56 lands first, since it's the identical diff.

First item from #53 (1 of 5); items 2 and 3 are #56 and #58.

## Test plan

- [x] New `ErrorMessagePanelTabOrderTest` - writes two log files out of alphabetical order with a real gap between creation times, asserts the resulting tab order is alphabetical regardless.
- [x] `./gradlew build` - clean.

## Related

- Fourth PR toward #53.
