### PR TITLE
build: bump mockito-core to 5.23.0 for JDK 26 support

### DIFF
--- a/cr-core/build.gradle.kts
+++ b/cr-core/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.mockito:mockito-core:5.6.0")
+    testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.slf4j:slf4j-api:2.0.18")
 
     testRuntimeOnly("ch.qos.logback:logback-classic:1.6.0")


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Mockito 5.6.0 bundles a ByteBuddy old enough that mock creation throws immediately on JDK 26+:

```
IllegalArgumentException: Java 26 (70) is not supported by the current version of Byte Buddy
which officially supports Java 21 (65) - update Byte Buddy or set net.bytebuddy.experimental
as a VM property
```

The error message's own suggested flag (`-Dnet.bytebuddy.experimental=true`) is a stopgap for running ahead of official support, not something to bake into the build permanently. `5.23.0` (latest) bundles ByteBuddy `1.17.7`, which supports JDK 26 natively.

Confirmed by running `runInteractiveTest` end to end with no flag: the mock now constructs fine, and the run gets to a real `GlobalProperties` issue several stages further in (see #56 - already fixed there and elsewhere, not touched here to keep this to one concern).

## Test plan

- [x] `./gradlew :cr-core:runInteractiveTest` on JDK 26 - the ByteBuddy/Mockito failure is gone.
- [x] `./gradlew build` - clean.

## Related

- Unblocks manual/interactive testing of #56/#58/#59/#60 on recent JDKs.
