### PR TITLE
fix(reporter): degrade to the placeholder image when a resource property is unset

### DIFF
--- a/cr-core/src/main/java/org/terasology/crashreporter/Resources.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/Resources.java
@@ -29,11 +29,7 @@ public final class Resources {
 
     /**
      * @param fname the absolute path in the jar/project, or {@code null} if the property naming it
-     *              was never set - e.g. {@code RES_BANNER_IMAGE}/{@code RES_SERVER_ICON} only exist
-     *              in a downstream consumer's {@code crashreporter.properties}
-     *              ({@code cr-terasology}, {@code cr-destsol}, ...), not {@code cr-core}'s own
-     *              {@code crashreporter_defaults.properties} - so any caller running against
-     *              {@code cr-core} alone can hit this with {@code null}, not just a bad filename.
+     *              was never set
      * @return the buffered image, wrapped in an Icon
      */
     public static BufferedImage loadImage(String fname) {

--- a/cr-core/src/main/java/org/terasology/crashreporter/Resources.java
+++ b/cr-core/src/main/java/org/terasology/crashreporter/Resources.java
@@ -28,10 +28,19 @@ public final class Resources {
     }
 
     /**
-     * @param fname the absolute path in the jar/project
+     * @param fname the absolute path in the jar/project, or {@code null} if the property naming it
+     *              was never set - e.g. {@code RES_BANNER_IMAGE}/{@code RES_SERVER_ICON} only exist
+     *              in a downstream consumer's {@code crashreporter.properties}
+     *              ({@code cr-terasology}, {@code cr-destsol}, ...), not {@code cr-core}'s own
+     *              {@code crashreporter_defaults.properties} - so any caller running against
+     *              {@code cr-core} alone can hit this with {@code null}, not just a bad filename.
      * @return the buffered image, wrapped in an Icon
      */
     public static BufferedImage loadImage(String fname) {
+        if (fname == null) {
+            System.err.println("No resource path given (missing property?) - using placeholder image");
+            return createDummyImage(64, 64, "?");
+        }
         try {
             String fullPath = "/" + fname;
             URL rsc = Resources.class.getResource(fullPath);


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

`Resources.loadImage(fname)` built `"/" + fname` and looked that up regardless of whether `fname` was `null`, so a missing property produced the literal path `"/null"` - `Resources.class.getResource("/null")` returns `null`, and the method threw `FileNotFoundException("/null")` instead of falling back to its own placeholder image the way it already does for a genuinely-missing-but-named resource.

`RES_BANNER_IMAGE`/`RES_SERVER_ICON` only exist in a downstream consumer's `crashreporter.properties` (`cr-terasology`, `cr-destsol`, ...), not `cr-core`'s own `crashreporter_defaults.properties` - so `GlobalProperties.get()` returning `null` for those keys is an expected, not exceptional, case whenever `cr-core` runs standalone. Confirmed while testing `runInteractiveTest`: this is exactly what crashed `RootPanel`'s banner image lookup and stopped the reporter dialog from ever rendering when run outside a downstream consumer.

## Test plan

- [x] `./gradlew build` - clean.

## Related

- Found while getting `runInteractiveTest` to actually render end to end for #56/#58/#59/#60 manual testing.
